### PR TITLE
Enhancement: Validate composer on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ php:
 
 before_install:
   - composer self-update
+  - composer validate
 
 install:
   - composer install --dev --prefer-source


### PR DESCRIPTION
This PR

* [x] validates `composer.json` and `composer.lock` in `before_install` section

Related to #6.

:information_desk_person: Noticed that `composer.lock` is not up to date in [`feature/inflector-config`](https://github.com/tomphp/config-service-provider/tree/feature/inflector-config)!