### PR TITLE
Fix: Remove --dev flag when installing, it's the default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
   - composer validate
 
 install:
-  - composer install --dev --prefer-source
+  - composer install --prefer-source
 
 script:
   - composer test


### PR DESCRIPTION
This PR

* [x] removes the `--dev` flag when installing dependencies, as it's the default value anyway