### PR TITLE
Fix: Add missing letter in test method name

### DIFF
--- a/tests/ConfigServiceProviderTest.php
+++ b/tests/ConfigServiceProviderTest.php
@@ -139,7 +139,7 @@ final class ConfigServiceProviderTest extends PHPUnit_Framework_TestCase
     /**
      * @group sub_providers
      */
-    public function testItSkipsConfiguringASubProvderWithNoConfig()
+    public function testItSkipsConfiguringASubProviderWithNoConfig()
     {
         new ConfigServiceProvider([], 'config', '.', [
             'sub_provider' => $this->subProvider->reveal(),


### PR DESCRIPTION
This PR

* [x] adds a letter missing from a test method name