### PR TITLE
Fix: Delete test files in tearDown()

### DIFF
--- a/tests/ConfigServiceProviderTest.php
+++ b/tests/ConfigServiceProviderTest.php
@@ -28,11 +28,6 @@ final class ConfigServiceProviderTest extends PHPUnit_Framework_TestCase
         $this->subProvider->register()->willReturn();
     }
 
-    protected function tearDown()
-    {
-        $this->deleteTestFiles();
-    }
-
     public function testItProvidesConfigValuesViaTheDI()
     {
         $config = [

--- a/tests/ConfigServiceProviderTest.php
+++ b/tests/ConfigServiceProviderTest.php
@@ -28,6 +28,11 @@ final class ConfigServiceProviderTest extends PHPUnit_Framework_TestCase
         $this->subProvider->register()->willReturn();
     }
 
+    protected function tearDown()
+    {
+        $this->deleteTestFiles();
+    }
+
     public function testItProvidesConfigValuesViaTheDI()
     {
         $config = [
@@ -271,8 +276,6 @@ final class ConfigServiceProviderTest extends PHPUnit_Framework_TestCase
      */
     public function testItCreatesFromParsingFiles()
     {
-        $this->deleteTestFiles();
-
         $config = [
             'test_key' => 'test value',
 
@@ -302,8 +305,6 @@ final class ConfigServiceProviderTest extends PHPUnit_Framework_TestCase
      */
     public function testItCanOverrideFromFilesDefaults()
     {
-        $this->deleteTestFiles();
-
         $config = [
             'test_key' => 'test value',
 
@@ -337,8 +338,6 @@ final class ConfigServiceProviderTest extends PHPUnit_Framework_TestCase
      */
     public function testItMergesConfigsFromFiles()
     {
-        $this->deleteTestFiles();
-
         $config1 = ['a' => 1, 'b' => 5];
         $config2 = ['b' => 2, 'c' => 3];
 

--- a/tests/FileLocatorTest.php
+++ b/tests/FileLocatorTest.php
@@ -16,9 +16,12 @@ final class FileLocatorTest extends PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->deleteTestFiles();
-
         $this->locator = new FileLocator();
+    }
+
+    protected function tearDown()
+    {
+        $this->deleteTestFiles();
     }
 
     public function testItFindsFilesByGlobbing()

--- a/tests/FileLocatorTest.php
+++ b/tests/FileLocatorTest.php
@@ -19,11 +19,6 @@ final class FileLocatorTest extends PHPUnit_Framework_TestCase
         $this->locator = new FileLocator();
     }
 
-    protected function tearDown()
-    {
-        $this->deleteTestFiles();
-    }
-
     public function testItFindsFilesByGlobbing()
     {
         $this->createTestFile('config1.php');

--- a/tests/JSONFileReaderTest.php
+++ b/tests/JSONFileReaderTest.php
@@ -20,11 +20,6 @@ final class JSONFileReaderTest extends PHPUnit_Framework_TestCase
         $this->reader = new JSONFileReader();
     }
 
-    protected function tearDown()
-    {
-        $this->deleteTestFiles();
-    }
-
     public function testItIsAFileReader()
     {
         $this->assertInstanceOf('TomPHP\ConfigServiceProvider\FileReader', $this->reader);

--- a/tests/JSONFileReaderTest.php
+++ b/tests/JSONFileReaderTest.php
@@ -17,9 +17,12 @@ final class JSONFileReaderTest extends PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->deleteTestFiles();
-
         $this->reader = new JSONFileReader();
+    }
+
+    protected function tearDown()
+    {
+        $this->deleteTestFiles();
     }
 
     public function testItIsAFileReader()

--- a/tests/PHPFileReaderTest.php
+++ b/tests/PHPFileReaderTest.php
@@ -17,9 +17,12 @@ final class PHPFileReaderTest extends PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->deleteTestFiles();
-
         $this->reader = new PHPFileReader();
+    }
+
+    protected function tearDown()
+    {
+        $this->deleteTestFiles();
     }
 
     public function testItIsAFileReader()

--- a/tests/PHPFileReaderTest.php
+++ b/tests/PHPFileReaderTest.php
@@ -20,11 +20,6 @@ final class PHPFileReaderTest extends PHPUnit_Framework_TestCase
         $this->reader = new PHPFileReader();
     }
 
-    protected function tearDown()
-    {
-        $this->deleteTestFiles();
-    }
-
     public function testItIsAFileReader()
     {
         $this->assertInstanceOf('TomPHP\ConfigServiceProvider\FileReader', $this->reader);

--- a/tests/TestFileCreator.php
+++ b/tests/TestFileCreator.php
@@ -9,6 +9,11 @@ trait TestFileCreator
      */
     private $configFilePath;
 
+    protected function tearDown()
+    {
+        $this->deleteTestFiles();
+    }
+
     /**
      * @param string $name
      *


### PR DESCRIPTION
This PR

* [x] deletes test files in `tearDown()`
* [x] moves `tearDown()` into `TestFileLocator` trait