### PR TITLE
Fix Allow to read from JSON files when using ConfigServiceProvider::fromFiles()

### DIFF
--- a/src/ConfigServiceProvider.php
+++ b/src/ConfigServiceProvider.php
@@ -68,6 +68,7 @@ final class ConfigServiceProvider extends AbstractServiceProvider implements
         $files = $locator->locate($patterns);
 
         $factory = new ReaderFactory([
+            '.json' => 'TomPHP\ConfigServiceProvider\JSONFileReader',
             '.php' => 'TomPHP\ConfigServiceProvider\PHPFileReader',
         ]);
 

--- a/tests/ConfigServiceProviderTest.php
+++ b/tests/ConfigServiceProviderTest.php
@@ -340,10 +340,12 @@ final class ConfigServiceProviderTest extends PHPUnit_Framework_TestCase
         $this->deleteTestFiles();
 
         $config1 = ['a' => 1, 'b' => 5];
-        $config2 = ['b' => 2, 'c' => 3];
+        $config2 = ['b' => 2, 'c' => 7];
+        $config3 = ['c' => 3, 'd' => 4];
 
         $this->createPHPConfigFile('config1.php', $config1);
         $this->createPHPConfigFile('config2.php', $config2);
+        $this->createJSONConfigFile('config3.json', $config3);
 
         $this->container->addServiceProvider(ConfigServiceProvider::fromFiles(
             [ $this->getTestPath('*') ]
@@ -352,11 +354,19 @@ final class ConfigServiceProviderTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(1, $this->container->get('config.a'));
         $this->assertEquals(2, $this->container->get('config.b'));
         $this->assertEquals(3, $this->container->get('config.c'));
+        $this->assertEquals(4, $this->container->get('config.d'));
     }
 
     private function createPHPConfigFile($filename, array $config)
     {
         $code = '<?php return ' . var_export($config, true) . ';';
+
+        $this->createTestFile($filename, $code);
+    }
+
+    private function createJSONConfigFile($filename, array $config)
+    {
+        $code = json_encode($config);
 
         $this->createTestFile($filename, $code);
     }


### PR DESCRIPTION
This PR

* [x] asserts that configuration will be also read from a JSON file when using `ConfigServiceProvider::fromFiles()`
* [x] registers the `JSONFileReader`
