### PR TITLE
Enhancement: Allow to glob with braces

### DIFF
--- a/src/FileLocator.php
+++ b/src/FileLocator.php
@@ -16,7 +16,7 @@ final class FileLocator
         $files = [];
 
         foreach ($patterns as $pattern) {
-            $files = array_merge($files, glob($pattern));
+            $files = array_merge($files, glob($pattern, GLOB_BRACE));
         }
 
         return $files;

--- a/tests/FileLocatorTest.php
+++ b/tests/FileLocatorTest.php
@@ -34,4 +34,19 @@ final class FileLocatorTest extends PHPUnit_Framework_TestCase
             $this->getTestPath('config2.php'),
         ], $files);
     }
+
+    public function testItFindsFindsFilesByGlobbingWithBraces()
+    {
+        $this->createTestFile('global.php');
+        $this->createTestFile('database.local.php');
+        $this->createTestFile('nothing.php');
+        $this->createTestFile('nothing.php.dist');
+
+        $files = $this->locator->locate([$this->getTestPath('{,*.}{global,local}.php')]);
+
+        $this->assertEquals([
+            $this->getTestPath('global.php'),
+            $this->getTestPath('database.local.php'),
+        ], $files);
+    }
 }


### PR DESCRIPTION
This PR

* [x] uses the `GLOB_BRACE` flag when `glob()`ing, so that we can have more advanced patterns

:information_desk_person: This is very useful (and, admittedly, influenced by [ZF2](https://github.com/zendframework/zend-modulemanager/blob/master/src/Listener/ConfigListener.php#L375-L377)) when you want to use more advanced patterns, say, load global configuration files first, then allow others to override.