### PR TITLE
Fix: Make sure that shared configuration values are raw values

### DIFF
--- a/src/ConfigServiceProvider.php
+++ b/src/ConfigServiceProvider.php
@@ -120,7 +120,9 @@ final class ConfigServiceProvider extends AbstractServiceProvider implements
     public function register()
     {
         foreach ($this->config as $key => $value) {
-            $this->getContainer()->add($key, $value);
+            $this->getContainer()->add($key, function () use ($value) {
+                return $value;
+            });
         }
 
         foreach ($this->subProviders as $provider) {

--- a/tests/ConfigServiceProviderTest.php
+++ b/tests/ConfigServiceProviderTest.php
@@ -381,6 +381,20 @@ final class ConfigServiceProviderTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(4, $this->container->get('config.d'));
     }
 
+    /**
+     * @link https://github.com/thephpleague/container/issues/106
+     */
+    public function testFetchingConfigValueWhereValueIsAClassNameReturnsValue()
+    {
+        $value = 'stdClass';
+
+        $this->container->addServiceProvider(ConfigServiceProvider::fromConfig([
+            'foo' => $value,
+        ]));
+
+        $this->assertSame($value, $this->container->get('config.foo'));
+    }
+
     private function createPHPConfigFile($filename, array $config)
     {
         $code = '<?php return ' . var_export($config, true) . ';';


### PR DESCRIPTION
This PR

* [x] asserts that `string`s are returned rather instances of the corresponding class
* [x] shares closures instead of raw values

🙎 Related to https://github.com/thephpleague/container/issues/106.