### PR TITLE
Fix: Remove unused local variable

### DIFF
--- a/tests/DIConfigServiceProviderTest.php
+++ b/tests/DIConfigServiceProviderTest.php
@@ -143,7 +143,7 @@ final class DIConfigServiceProviderTest extends PHPUnit_Framework_TestCase
 
         $this->setExpectedException('TomPHP\ConfigServiceProvider\Exception\NotClassDefinitionException');
 
-        $instance = $this->container->get('example_class');
+        $this->container->get('example_class');
     }
 
     public function testCanBeReconfigured()


### PR DESCRIPTION
This PR

* [x] removes an unused local variable