### PR TITLE
Fix: Add arguments to docblocks

### DIFF
--- a/src/ConfigServiceProvider.php
+++ b/src/ConfigServiceProvider.php
@@ -210,6 +210,8 @@ final class ConfigServiceProvider extends AbstractServiceProvider implements
 
     /**
      * @param string $key
+     * @param array $config
+     * @param ConfigurableServiceProvider $provider
      */
     private function configureSubProvider($key, $config, ConfigurableServiceProvider $provider)
     {

--- a/src/DIConfigServiceProvider.php
+++ b/src/DIConfigServiceProvider.php
@@ -68,6 +68,7 @@ final class DIConfigServiceProvider extends AbstractServiceProvider implements
     }
 
     /**
+     * @param ClassDefinition $service
      * @param array $config
      */
     private function addConstuctorArguments(ClassDefinition $service, array $config)
@@ -80,6 +81,7 @@ final class DIConfigServiceProvider extends AbstractServiceProvider implements
     }
 
     /**
+     * @param ClassDefinition $service
      * @param array $config
      */
     private function addMethodCalls(ClassDefinition $service, array $config)


### PR DESCRIPTION
This PR

* [x] adds arguments missing from docblocks