### PR TITLE
Fix: Cache dependencies between builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,16 @@ php:
   - 7.0
   - hhvm
 
+cache:
+  directories:
+    - $HOME/.composer/cache
+
 before_install:
   - composer self-update
   - composer validate
 
 install:
-  - composer install --prefer-source
+  - composer install --prefer-dist
 
 script:
   - composer test


### PR DESCRIPTION
This PR

* [x] attempts to cache dependencies installed with `composer` between builds