### PR TITLE
Fix: Add missing $ to docblock

### DIFF
--- a/src/Exception/EntryDoesNotExistException.php
+++ b/src/Exception/EntryDoesNotExistException.php
@@ -9,7 +9,7 @@ final class EntryDoesNotExistException extends DomainException implements Except
     use ExceptionFactory;
 
     /**
-     * @param string key
+     * @param string $key
      *
      * @return self
      */


### PR DESCRIPTION
This PR

* [x] adds a missing `$` to a docblock