### PR TITLE
Fix: Use expectException() instead of deprecated setExpectedException()

### DIFF
--- a/tests/acceptance/DoesNotSupportInflectors.php
+++ b/tests/acceptance/DoesNotSupportInflectors.php
@@ -9,7 +9,7 @@ trait DoesNotSupportInflectors
 {
     public function testInflectorsAreUnsupported()
     {
-        $this->setExpectedException(UnsupportedFeatureException::class);
+        $this->expectException(UnsupportedFeatureException::class);
 
         $config = [
             'di' => [

--- a/tests/unit/ApplicationConfigTest.php
+++ b/tests/unit/ApplicationConfigTest.php
@@ -97,21 +97,21 @@ final class ApplicationConfigTest extends PHPUnit_Framework_TestCase
 
     public function testItThrowsForAnEmptySeparatorOnConstruction()
     {
-        $this->setExpectedException(InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         $this->config = new ApplicationConfig([], '');
     }
 
     public function testItCannotHaveAValueSet()
     {
-        $this->setExpectedException(ReadOnlyException::class);
+        $this->expectException(ReadOnlyException::class);
 
         $this->config['key'] = 'value';
     }
 
     public function testItCannotHaveAValueRemoved()
     {
-        $this->setExpectedException(ReadOnlyException::class);
+        $this->expectException(ReadOnlyException::class);
 
         unset($this->config['keyA']);
     }
@@ -146,7 +146,7 @@ final class ApplicationConfigTest extends PHPUnit_Framework_TestCase
 
     public function testItThrowsForAnEmptySeparatorWhenSettingSeparator()
     {
-        $this->setExpectedException(InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         $this->config = new ApplicationConfig([]);
         $this->config->setSeparator('');

--- a/tests/unit/ConfiguratorTest.php
+++ b/tests/unit/ConfiguratorTest.php
@@ -14,14 +14,14 @@ final class ConfiguratorTest extends PHPUnit_Framework_TestCase
 
     public function testItThrowsAnExceptionWhenNoFilesAreNotFound()
     {
-        $this->setExpectedException(NoMatchingFilesException::class);
+        $this->expectException(NoMatchingFilesException::class);
 
         Configurator::apply()->configFromFiles($this->getTestPath('config.php'));
     }
 
     public function testItThrowsWhenAnUnknownSettingIsSet()
     {
-        $this->setExpectedException(UnknownSettingException::class);
+        $this->expectException(UnknownSettingException::class);
 
         Configurator::apply()->withSetting('unknown_setting', 'value');
     }

--- a/tests/unit/ContainerAdapterFactoryTest.php
+++ b/tests/unit/ContainerAdapterFactoryTest.php
@@ -41,7 +41,7 @@ final class ContainerAdapterFactoryTest extends PHPUnit_Framework_TestCase
 
     public function testItThrowsIfContainerIsNotKnown()
     {
-        $this->setExpectedException(UnknownContainerException::class);
+        $this->expectException(UnknownContainerException::class);
 
         $this->subject->create(new \stdClass());
     }

--- a/tests/unit/FileReader/JSONFileReaderTest.php
+++ b/tests/unit/FileReader/JSONFileReaderTest.php
@@ -30,7 +30,7 @@ final class JSONFileReaderTest extends PHPUnit_Framework_TestCase
 
     public function testItThrowsIfFileDoesNotExist()
     {
-        $this->setExpectedException(FileNotFoundException::class);
+        $this->expectException(FileNotFoundException::class);
 
         $this->reader->read('file-which-does-not-exist');
     }
@@ -46,7 +46,7 @@ final class JSONFileReaderTest extends PHPUnit_Framework_TestCase
 
     public function testItThrowsIfTheConfigIsInvalid()
     {
-        $this->setExpectedException(InvalidConfigException::class);
+        $this->expectException(InvalidConfigException::class);
 
         $this->createTestFile('config.json', 'not json');
 

--- a/tests/unit/FileReader/PHPFileReaderTest.php
+++ b/tests/unit/FileReader/PHPFileReaderTest.php
@@ -30,7 +30,7 @@ final class PHPFileReaderTest extends PHPUnit_Framework_TestCase
 
     public function testItThrowsIfFileDoesNotExist()
     {
-        $this->setExpectedException(FileNotFoundException::class);
+        $this->expectException(FileNotFoundException::class);
 
         $this->reader->read('file-which-does-not-exist');
     }
@@ -47,7 +47,7 @@ final class PHPFileReaderTest extends PHPUnit_Framework_TestCase
 
     public function testItThrowsIfTheConfigIsInvalid()
     {
-        $this->setExpectedException(InvalidConfigException::class);
+        $this->expectException(InvalidConfigException::class);
 
         $code = '<?php return 123;';
         $this->createTestFile('config.php', $code);

--- a/tests/unit/FileReader/ReaderFactoryTest.php
+++ b/tests/unit/FileReader/ReaderFactoryTest.php
@@ -47,7 +47,7 @@ final class ReaderFactoryTest extends PHPUnit_Framework_TestCase
 
     public function testItThrowsIfThereIsNoRegisteredReaderForGivenFileType()
     {
-        $this->setExpectedException(UnknownFileTypeException::class);
+        $this->expectException(UnknownFileTypeException::class);
 
         $this->factory->create('test.unknown');
     }


### PR DESCRIPTION
This PR

* [x] uses `expectException()` instead of deprecated `setExpectedException()`

Follows #45.