### PR TITLE
Fix: Adjust Travis configuration and require build for HHVM to pass

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 matrix:
   include:
     - php: 5.6
+      env: WITH_CS=true
     - php: 7.0
     - php: 7.1
     - php: hhvm
@@ -22,5 +23,6 @@ install:
   - composer install --prefer-dist
 
 script:
+  - if [[ $WITH_CS == "true" ]] ; then composer cs:check; fi
   - composer test
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,14 @@
 language: php
 
-php:
-  - 5.6
-  - 7.0
-  - 7.1
-  - hhvm
+matrix:
+  include:
+    - php: 5.6
+    - php: 7.0
+    - php: 7.1
+    - php: hhvm
+      sudo: required
+      dist: trusty
+      group: edge
 
 cache:
   directories:
@@ -20,7 +24,3 @@ install:
 script:
   - composer test
 
-matrix:
-  fast_finish: true
-  allow_failures:
-    - php: hhvm

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,11 @@ Then the tests can be run using the following command:
 $ composer test
 ```
 
-This will also check for the PSR-2 Coding Standard compliance.
+Then the checks for the PSR-2 Coding Standard compliance can be run using the following command:
+
+```
+$ composer cs:check
+```
 
 ## Travis
 

--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,6 @@
             "php-cs-fixer fix --dry-run --verbose"
         ],
         "test": [
-            "@cs:check",
             "phpunit --colors=always"
         ]
     }

--- a/src/Configurator.php
+++ b/src/Configurator.php
@@ -15,18 +15,6 @@ final class Configurator
     const SETTING_INFLECTORS_KEY             = 'inflectors_key';
     const SETTING_DEFAULT_SINGLETON_SERVICES = 'default_singleton_services';
 
-    const FILE_READERS = [
-        '.json' => FileReader\JSONFileReader::class,
-        '.php'  => FileReader\PHPFileReader::class,
-        '.yaml' => FileReader\YAMLFileReader::class,
-        '.yml'  => FileReader\YAMLFileReader::class,
-    ];
-
-    const CONTAINER_ADAPTERS = [
-        \League\Container\Container::class => League\LeagueContainerAdapter::class,
-        \Pimple\Container::class           => Pimple\PimpleContainerAdapter::class,
-    ];
-
     /**
      * @var ApplicationConfig
      */
@@ -51,12 +39,20 @@ final class Configurator
     /**
      * @var string[]
      */
-    private $fileReaders = self::FILE_READERS;
+    private $fileReaders = [
+        '.json' => FileReader\JSONFileReader::class,
+        '.php'  => FileReader\PHPFileReader::class,
+        '.yaml' => FileReader\YAMLFileReader::class,
+        '.yml'  => FileReader\YAMLFileReader::class,
+    ];
 
     /**
      * @var string[]
      */
-    private $containerAdapters = self::CONTAINER_ADAPTERS;
+    private $containerAdapters = [
+        \League\Container\Container::class => League\LeagueContainerAdapter::class,
+        \Pimple\Container::class           => Pimple\PimpleContainerAdapter::class,
+    ];
 
     /**
      * @var string


### PR DESCRIPTION
This PR

* [x] adjusts the Travis configuration and requires the build for HHVM to pass
* [x] adjusts the `test` script and runs `composer cs:check` on PHP5.6 only
* [x] removes constants defining arrays (see https://travis-ci.org/tomphp/container-configurator/jobs/203518123#L758-L760)

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/master/.travis.yml#L33-L42).