### PR TITLE
Drop support for PHP 5.6 and PHP 7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ vendor
 tests/.test-config
 .php_cs.cache
 composer.lock
+.php-cs-fixer.cache
+.phpunit.result.cache
+.devcontainer

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -2,42 +2,47 @@
 
 $finder = PhpCsFixer\Finder::create()->in(__DIR__);
 
-return PhpCsFixer\Config::create()
+return (new PhpCsFixer\Config())
     ->setRules([
-        '@PSR2'                                       => true,
+        '@PSR12'                                      => true,
         'array_syntax'                                => [
             'syntax' => 'short',
         ],
-        'binary_operator_spaces'                      => [
-            'align_double_arrow' => true,
-            'align_equals' => true,
+        'binary_operator_spaces' => [
+            'operators' => [
+                '=>' => 'align',
+                '=' => 'align',
+            ],
         ],
         'concat_space'                                => [
             'spacing' => 'one',
         ],
-        'function_typehint_space'                     => true,
-        'hash_to_slash_comment'                       => true,
-        'include'                                     => true,
+        'declare_strict_types'                        => true,
+        'type_declaration_spaces'                     => true,
+        'single_line_comment_style' => [
+            'comment_types' => ['hash'],
+        ],
         'lowercase_cast'                              => true,
-        'method_separation'                           => true,
+        'class_attributes_separation' => [
+            'elements' => ['method' => 'one', 'property' => 'one', 'const' => 'one'],
+        ],
         'native_function_casing'                      => true,
-        'new_with_braces'                             => true,
+        'new_with_parentheses'                        => true,
         'no_alias_functions'                          => true,
         'no_blank_lines_after_class_opening'          => true,
         'no_blank_lines_after_phpdoc'                 => true,
         'no_empty_comment'                            => true,
         'no_empty_phpdoc'                             => true,
         'no_empty_statement'                          => true,
-        'no_extra_consecutive_blank_lines'            => true,
+        'no_extra_blank_lines'                        => true,
         'no_leading_import_slash'                     => true,
         'no_leading_namespace_whitespace'             => true,
         'no_multiline_whitespace_around_double_arrow' => true,
-        'no_multiline_whitespace_before_semicolons'   => true,
+        'multiline_whitespace_before_semicolons'      => false,
         'no_short_bool_cast'                          => true,
         'no_singleline_whitespace_before_semicolons'  => true,
         'no_spaces_around_offset'                     => true,
-        'no_trailing_comma_in_list_call'              => true,
-        'no_trailing_comma_in_singleline_array'       => true,
+        'no_trailing_comma_in_singleline'             => true,
         'no_unreachable_default_argument_value'       => true,
         'no_unused_imports'                           => true,
         'no_useless_else'                             => true,
@@ -47,12 +52,9 @@ return PhpCsFixer\Config::create()
         'ordered_imports'                             => true,
         'phpdoc_align'                                => true,
         'phpdoc_indent'                               => true,
-        'phpdoc_inline_tag'                           => true,
-        'phpdoc_no_access'                            => true,
-        'phpdoc_no_alias_tag'                         => [
-            'type' => 'var',
-        ],
-        'phpdoc_no_package'                           => true,
+        'general_phpdoc_tag_rename'                   => true,
+        'phpdoc_inline_tag_normalizer'                => true,
+        'phpdoc_tag_type'                             => true,
         'phpdoc_order'                                => true,
         'phpdoc_scalar'                               => true,
         'phpdoc_separation'                           => true,
@@ -63,11 +65,12 @@ return PhpCsFixer\Config::create()
         'phpdoc_types'                                => true,
         'self_accessor'                               => true,
         'short_scalar_cast'                           => true,
-        'single_blank_line_before_namespace'          => true,
         'single_quote'                                => true,
         'space_after_semicolon'                       => true,
         'standardize_not_equals'                      => true,
-        'trailing_comma_in_multiline_array'           => true,
+        'trailing_comma_in_multiline' => [
+            'elements' => ['arrays'],
+        ],
         'trim_array_spaces'                           => true,
         'unary_operator_spaces'                       => true,
         'whitespace_after_comma_in_array'             => true,

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: php
 
 php:
-  - 5.6
-  - 7.0
-  - 7.1
-  - hhvm
+  - 8.1
+  - 8.2
+  - 8.3
+  - 8.4
 
 cache:
   directories:
@@ -22,5 +22,3 @@ script:
 
 matrix:
   fast_finish: true
-  allow_failures:
-    - php: hhvm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,23 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## 1.0.0 - 2015-19-31
+## 2.0.0 - 2025-08-12
+
+### Changed
+
+  * Minimum supported PHP version is now `8.1`.
+  * Upgraded dependencies:
+    * beberlei/assert to `^3.3`
+    * symfony/yaml to `^6.4`
+    * tomphp/exception-constructor-tools to `^2.0`
+
+### Added
+
+  * `TomPHP\ContainerConfigurator\FileReader\HJSONFileReader` for reading
+     HJSON files (requires `laktak/hjson` to be installed).
+  * `phpstan/phpstan` applied at max level with code cleanup
+
+## 1.0.0 - 2015-09-31
 ### Added
   * Inflector support for Pimple.
   * Custom file readers with `withFileReader(string $extension, string $readerClass);`.

--- a/composer.json
+++ b/composer.json
@@ -15,21 +15,25 @@
     ],
     "suggest": {
         "league/container": "Small but powerful dependency injection container http://container.thephpleague.com",
-        "pimple/pimple": "A small PHP 5.3 dependency injection container http://pimple.sensiolabs.org",
-        "symfony/yaml": "For reading configuration from YAML files"
+        "pimple/pimple": "A small PHP dependency injection container https://github.com/silexphp/Pimple",
+        "symfony/yaml": "For reading configuration from YAML files",
+        "laktak/hjson": "For reading configuration from HJSON files"
     },
     "require": {
-        "php": "^5.6|^7.0",
-        "beberlei/assert": "^2.6",
-        "tomphp/exception-constructor-tools": "^1.0.0"
+        "php": "^8.1",
+        "beberlei/assert": "^3.3",
+        "tomphp/exception-constructor-tools": "^2.0"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^2.1.0",
-        "league/container": "^2.0.2",
-        "phpunit/phpunit": "^5.5.4",
-        "pimple/pimple": "^3.0.0",
-        "squizlabs/php_codesniffer": "^2.8.0",
-        "symfony/yaml": "^3.1.4"
+        "friendsofphp/php-cs-fixer": "^3.85",
+        "laktak/hjson": "^2.3",
+        "league/container": "^5.1",
+        "phpstan/phpstan": "^2.1",
+        "phpunit/phpunit": "^9.6 || ^7.5 || ^11.5",
+        "pimple/pimple": "^3.5",
+        "rector/rector": "^2.1",
+        "squizlabs/php_codesniffer": "^3.9",
+        "symfony/yaml": "^6.4"
     },
     "autoload": {
         "psr-4": {
@@ -59,8 +63,18 @@
             "phpcs --standard=psr2 src tests",
             "php-cs-fixer fix --dry-run --verbose"
         ],
+        "analyse": [
+            "phpstan analyse --memory-limit=1G"
+        ],
+        "rector": [
+            "rector process src tests --ansi"
+        ],
+        "rector:dry": [
+            "rector process src tests --dry-run --ansi"
+        ],
         "test": [
             "@cs:check",
+            "@analyse",
             "phpunit --colors=always"
         ]
     }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,7 @@
+parameters:
+    level: max
+
+    paths:
+        - src/
+
+    treatPhpDocTypesAsCertain: false

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Set\ValueObject\LevelSetList;
+use Rector\Set\ValueObject\SetList;
+
+return RectorConfig::configure()
+    ->withPaths([
+        __DIR__ . '/src',
+        __DIR__ . '/tests',
+    ])
+    // Ensure Rector knows we are targeting PHP 8.1+ syntax and features
+    ->withPhpSets(php81: true)
+    ->withPreparedSets(
+        typeDeclarations: true,       // Add param/return/var types where possible
+        earlyReturn: true,            // Replace nested ifs with early returns
+        strictBooleans: true,         // Use strict bool checks
+        phpunitCodeQuality: true,     // Modernise PHPUnit usage
+        deadCode: true                // Remove unused code, vars, imports, etc.
+    )
+    ->withSets([
+        LevelSetList::UP_TO_PHP_81,   // Enforces all rules up to PHP 8.1
+        SetList::CODE_QUALITY,
+        SetList::CODING_STYLE,
+        SetList::DEAD_CODE,
+        SetList::NAMING,              // Enforce clear & consistent naming
+        SetList::TYPE_DECLARATION,    // Add missing type declarations aggressively
+        SetList::PRIVATIZATION,       // Make props/methods private if possible
+        SetList::STRICT_BOOLEANS,     // Strict boolean expressions
+    ])->withPHPStanConfigs([
+        __DIR__ . '/phpstan.neon.dist',
+    ]);

--- a/src/ApplicationConfigIterator.php
+++ b/src/ApplicationConfigIterator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace TomPHP\ContainerConfigurator;
 
 use RecursiveArrayIterator;
@@ -7,53 +9,52 @@ use RecursiveIteratorIterator;
 
 /**
  * @internal
+ *
+ * @extends RecursiveIteratorIterator<RecursiveArrayIterator>
  */
 final class ApplicationConfigIterator extends RecursiveIteratorIterator
 {
     /**
      * @var string[]
      */
-    private $path = [];
+    private array $path = [];
 
-    /**
-     * @var string
-     */
-    private $separator;
+    private readonly string $separator;
 
-    /**
-     * @param ApplicationConfig $config
-     */
-    public function __construct(ApplicationConfig $config)
+    public function __construct(ApplicationConfig $applicationConfig)
     {
         parent::__construct(
-            new RecursiveArrayIterator($config->asArray()),
+            new RecursiveArrayIterator($applicationConfig->asArray()),
             RecursiveIteratorIterator::SELF_FIRST
         );
-        $this->separator = $config->getSeparator();
+        $this->separator = $applicationConfig->getSeparator();
     }
 
-    public function key()
+    public function key(): mixed
     {
         return implode($this->separator, array_merge($this->path, [parent::key()]));
     }
 
-    public function next()
+    public function next(): void
     {
         if ($this->callHasChildren()) {
-            array_push($this->path, parent::key());
+            $key = parent::key();
+            if (is_string($key) || is_int($key) || ($key instanceof \Stringable)) {
+                $this->path[] = (string) $key;
+            }
         }
 
         parent::next();
     }
 
-    public function rewind()
+    public function rewind(): void
     {
         $this->path = [];
 
         parent::rewind();
     }
 
-    public function endChildren()
+    public function endChildren(): void
     {
         array_pop($this->path);
     }

--- a/src/ContainerAdapter.php
+++ b/src/ContainerAdapter.php
@@ -1,39 +1,21 @@
 <?php
 
+declare(strict_types=1);
+
 namespace TomPHP\ContainerConfigurator;
 
 use InvalidArgumentException;
 
 interface ContainerAdapter
 {
-    /**
-     * @param object $container
-     *
-     * @return void
-     */
-    public function setContainer($container);
+    public function setContainer(object $container): void;
 
     /**
-     * @param ApplicationConfig $config
-     * @param string            $prefix
-     *
      * @throws InvalidArgumentException
-     *
-     * @return void
      */
-    public function addApplicationConfig(ApplicationConfig $config, $prefix = 'config');
+    public function addApplicationConfig(ApplicationConfig $applicationConfig, string $prefix = 'config'): void;
 
-    /**
-     * @param ServiceConfig $config
-     *
-     * @return void
-     */
-    public function addServiceConfig(ServiceConfig $config);
+    public function addServiceConfig(ServiceConfig $serviceConfig): void;
 
-    /**
-     * @param InflectorConfig $config
-     *
-     * @return void
-     */
-    public function addInflectorConfig(InflectorConfig $config);
+    public function addInflectorConfig(InflectorConfig $inflectorConfig): void;
 }

--- a/src/ContainerAdapterFactory.php
+++ b/src/ContainerAdapterFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace TomPHP\ContainerConfigurator;
 
 use TomPHP\ContainerConfigurator\Exception\NotContainerAdapterException;
@@ -11,13 +13,10 @@ use TomPHP\ContainerConfigurator\Exception\UnknownContainerException;
 final class ContainerAdapterFactory
 {
     /**
-     * @var array
+     * @param array<string,string> $config
      */
-    private $config;
-
-    public function __construct(array $config)
+    public function __construct(private readonly array $config)
     {
-        $this->config = $config;
     }
 
     /**
@@ -41,7 +40,7 @@ final class ContainerAdapterFactory
 
         if (!$class) {
             throw UnknownContainerException::fromContainerName(
-                get_class($container),
+                $container::class,
                 array_keys($this->config)
             );
         }

--- a/src/Exception/EntryDoesNotExistException.php
+++ b/src/Exception/EntryDoesNotExistException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace TomPHP\ContainerConfigurator\Exception;
 
 use DomainException;
@@ -11,12 +13,8 @@ final class EntryDoesNotExistException extends DomainException implements Except
 
     /**
      * @internal
-     *
-     * @param string $key
-     *
-     * @return self
      */
-    public static function fromKey($key)
+    public static function fromKey(string $key): self
     {
         return self::create('No entry found for "%s".', [$key]);
     }

--- a/src/Exception/Exception.php
+++ b/src/Exception/Exception.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace TomPHP\ContainerConfigurator\Exception;
 
 interface Exception

--- a/src/Exception/InvalidConfigException.php
+++ b/src/Exception/InvalidConfigException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace TomPHP\ContainerConfigurator\Exception;
 
 use LogicException;
@@ -11,50 +13,40 @@ final class InvalidConfigException extends LogicException implements Exception
 
     /**
      * @internal
-     *
-     * @param string $filename
-     *
-     * @return self
      */
-    public static function fromPHPFileError($filename)
+    public static function fromPHPFileError(string $filename): static
     {
         return self::create('"%s" does not return a PHP array.', [$filename]);
     }
 
     /**
      * @internal
-     *
-     * @param string $filename
-     * @param string $message
-     *
-     * @return self
      */
-    public static function fromJSONFileError($filename, $message)
+    public static function fromJSONFileError(string $filename, string $message): static
     {
         return self::create('Invalid JSON in "%s": %s', [$filename, $message]);
     }
 
     /**
      * @internal
-     *
-     * @param string $filename
-     * @param string $message
-     *
-     * @return self
      */
-    public static function fromYAMLFileError($filename, $message)
+    public static function fromHJSONFileError(string $filename, string $message): static
+    {
+        return self::create('Invalid HJSON in "%s": %s', [$filename, $message]);
+    }
+
+    /**
+     * @internal
+     */
+    public static function fromYAMLFileError(string $filename, string $message): static
     {
         return self::create('Invalid YAML in "%s": %s', [$filename, $message]);
     }
 
     /**
      * @internal
-     *
-     * @param string $name
-     *
-     * @return self
      */
-    public static function fromNameWhenClassAndFactorySpecified($name)
+    public static function fromNameWhenClassAndFactorySpecified(string $name): static
     {
         return self::create(
             'Both "class" and "factory" are specified for service "%s"; these cannot be used together.',
@@ -64,12 +56,8 @@ final class InvalidConfigException extends LogicException implements Exception
 
     /**
      * @internal
-     *
-     * @param string $name
-     *
-     * @return self
      */
-    public static function fromNameWhenClassAndServiceSpecified($name)
+    public static function fromNameWhenClassAndServiceSpecified(string $name): static
     {
         return self::create(
             'Both "class" and "service" are specified for service "%s"; these cannot be used together.',
@@ -79,12 +67,8 @@ final class InvalidConfigException extends LogicException implements Exception
 
     /**
      * @internal
-     *
-     * @param string $name
-     *
-     * @return self
      */
-    public static function fromNameWhenFactoryAndServiceSpecified($name)
+    public static function fromNameWhenFactoryAndServiceSpecified(string $name): self
     {
         return self::create(
             'Both "factory" and "service" are specified for service "%s"; these cannot be used together.',

--- a/src/Exception/MissingDependencyException.php
+++ b/src/Exception/MissingDependencyException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace TomPHP\ContainerConfigurator\Exception;
 
 use LogicException;
@@ -11,12 +13,8 @@ final class MissingDependencyException extends LogicException implements Excepti
 
     /**
      * @internal
-     *
-     * @param string $packageName
-     *
-     * @return self
      */
-    public static function fromPackageName($packageName)
+    public static function fromPackageName(string $packageName): self
     {
         return self::create('The package "%s" is missing. Please run "composer require %s" to install it.', [
             $packageName,

--- a/src/Exception/NoMatchingFilesException.php
+++ b/src/Exception/NoMatchingFilesException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace TomPHP\ContainerConfigurator\Exception;
 
 use LogicException;
@@ -11,12 +13,8 @@ final class NoMatchingFilesException extends LogicException implements Exception
 
     /**
      * @internal
-     *
-     * @param string $pattern
-     *
-     * @return self
      */
-    public static function fromPattern($pattern)
+    public static function fromPattern(string $pattern): self
     {
         return self::create('No files found matching pattern: "%s".', [$pattern]);
     }

--- a/src/Exception/NotClassDefinitionException.php
+++ b/src/Exception/NotClassDefinitionException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace TomPHP\ContainerConfigurator\Exception;
 
 use LogicException;
@@ -11,12 +13,8 @@ final class NotClassDefinitionException extends LogicException implements Except
 
     /**
      * @internal
-     *
-     * @param string $name
-     *
-     * @return self
      */
-    public static function fromServiceName($name)
+    public static function fromServiceName(string $name): self
     {
         return self::create(
             'Service configuration for "%s" did not create a class definition.',

--- a/src/Exception/NotFactoryException.php
+++ b/src/Exception/NotFactoryException.php
@@ -7,7 +7,7 @@ namespace TomPHP\ContainerConfigurator\Exception;
 use LogicException;
 use TomPHP\ExceptionConstructorTools;
 
-final class NotContainerAdapterException extends LogicException implements Exception
+final class NotFactoryException extends LogicException implements Exception
 {
     use ExceptionConstructorTools;
 
@@ -17,7 +17,7 @@ final class NotContainerAdapterException extends LogicException implements Excep
     public static function fromClassName(string $name): self
     {
         return self::create(
-            'Class "%s" is not a container adapter.',
+            'Class "%s" is not a factory.',
             [$name]
         );
     }

--- a/src/Exception/NotFileReaderException.php
+++ b/src/Exception/NotFileReaderException.php
@@ -7,7 +7,7 @@ namespace TomPHP\ContainerConfigurator\Exception;
 use LogicException;
 use TomPHP\ExceptionConstructorTools;
 
-final class NotContainerAdapterException extends LogicException implements Exception
+final class NotFileReaderException extends LogicException implements Exception
 {
     use ExceptionConstructorTools;
 
@@ -17,7 +17,7 @@ final class NotContainerAdapterException extends LogicException implements Excep
     public static function fromClassName(string $name): self
     {
         return self::create(
-            'Class "%s" is not a container adapter.',
+            'Class "%s" is not a file reader.',
             [$name]
         );
     }

--- a/src/Exception/ReadOnlyException.php
+++ b/src/Exception/ReadOnlyException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace TomPHP\ContainerConfigurator\Exception;
 
 use LogicException;
@@ -11,12 +13,8 @@ final class ReadOnlyException extends LogicException implements Exception
 
     /**
      * @internal
-     *
-     * @param string $name
-     *
-     * @return self
      */
-    public static function fromClassName($name)
+    public static function fromClassName(string $name): self
     {
         return self::create('"%s" is read only.', [$name]);
     }

--- a/src/Exception/UnknownContainerException.php
+++ b/src/Exception/UnknownContainerException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace TomPHP\ContainerConfigurator\Exception;
 
 use LogicException;
@@ -12,12 +14,9 @@ final class UnknownContainerException extends LogicException implements Exceptio
     /**
      * @internal
      *
-     * @param string   $name
      * @param string[] $knownContainers
-     *
-     * @return self
      */
-    public static function fromContainerName($name, array $knownContainers)
+    public static function fromContainerName(string $name, array $knownContainers): self
     {
         return self::create(
             'Container %s is unknown; known containers are %s.',

--- a/src/Exception/UnknownFileTypeException.php
+++ b/src/Exception/UnknownFileTypeException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace TomPHP\ContainerConfigurator\Exception;
 
 use DomainException;
@@ -12,12 +14,9 @@ final class UnknownFileTypeException extends DomainException implements Exceptio
     /**
      * @internal
      *
-     * @param string   $extension
      * @param string[] $availableExtensions
-     *
-     * @return self
      */
-    public static function fromFileExtension($extension, array $availableExtensions)
+    public static function fromFileExtension(string $extension, array $availableExtensions): self
     {
         return self::create(
             'No reader configured for "%s" files; readers are available for %s.',

--- a/src/Exception/UnknownSettingException.php
+++ b/src/Exception/UnknownSettingException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace TomPHP\ContainerConfigurator\Exception;
 
 use DomainException;
@@ -12,12 +14,9 @@ final class UnknownSettingException extends DomainException implements Exception
     /**
      * @internal
      *
-     * @param string   $setting
      * @param string[] $knownSettings
-     *
-     * @return self
      */
-    public static function fromSetting($setting, array $knownSettings)
+    public static function fromSetting(string $setting, array $knownSettings): self
     {
         return self::create(
             'Setting "%s" is unknown; valid settings are %s.',

--- a/src/FileReader/FileLocator.php
+++ b/src/FileReader/FileLocator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace TomPHP\ContainerConfigurator\FileReader;
 
 use Assert\Assertion;
@@ -11,16 +13,14 @@ use InvalidArgumentException;
 final class FileLocator
 {
     /**
-     * @param string $pattern
-     *
      * @throws InvalidArgumentException
      *
      * @return string[]
      */
-    public function locate($pattern)
+    public function locate(string $pattern): array
     {
         Assertion::string($pattern);
 
-        return glob($pattern, GLOB_BRACE);
+        return glob($pattern, GLOB_BRACE) ?: [];
     }
 }

--- a/src/FileReader/FileReader.php
+++ b/src/FileReader/FileReader.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace TomPHP\ContainerConfigurator\FileReader;
 
 use InvalidArgumentException;
@@ -8,12 +10,8 @@ use TomPHP\ContainerConfigurator\Exception\InvalidConfigException;
 interface FileReader
 {
     /**
-     * @param string $filename
-     *
      * @throws InvalidConfigException
      * @throws InvalidArgumentException
-     *
-     * @return array
      */
-    public function read($filename);
+    public function read(string $filename): mixed;
 }

--- a/src/FileReader/PHPFileReader.php
+++ b/src/FileReader/PHPFileReader.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace TomPHP\ContainerConfigurator\FileReader;
 
 use Assert\Assertion;
@@ -10,9 +12,9 @@ use TomPHP\ContainerConfigurator\Exception\InvalidConfigException;
  */
 final class PHPFileReader implements FileReader
 {
-    private $filename;
+    private string $filename;
 
-    public function read($filename)
+    public function read(string $filename): mixed
     {
         Assertion::file($filename);
 
@@ -25,7 +27,7 @@ final class PHPFileReader implements FileReader
         return $config;
     }
 
-    private function assertConfigIsValid($config)
+    private function assertConfigIsValid(mixed $config): void
     {
         if (!is_array($config)) {
             throw InvalidConfigException::fromPHPFileError($this->filename);

--- a/src/FileReader/YAMLFileReader.php
+++ b/src/FileReader/YAMLFileReader.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace TomPHP\ContainerConfigurator\FileReader;
 
 use Assert\Assertion;
@@ -22,14 +24,14 @@ final class YAMLFileReader implements FileReader
         }
     }
 
-    public function read($filename)
+    public function read(string $filename): mixed
     {
         Assertion::file($filename);
 
         try {
-            $config = Yaml\Yaml::parse(file_get_contents($filename));
-        } catch (Yaml\Exception\ParseException $exception) {
-            throw InvalidConfigException::fromYAMLFileError($filename, $exception->getMessage());
+            $config = Yaml\Yaml::parse(file_get_contents($filename) ?: '');
+        } catch (Yaml\Exception\ParseException $parseException) {
+            throw InvalidConfigException::fromYAMLFileError($filename, $parseException->getMessage());
         }
 
         return $config;

--- a/src/InflectorConfig.php
+++ b/src/InflectorConfig.php
@@ -1,27 +1,30 @@
 <?php
 
+declare(strict_types=1);
+
 namespace TomPHP\ContainerConfigurator;
 
 use ArrayIterator;
 use IteratorAggregate;
+use Traversable;
 
 /**
  * @internal
+ *
+ * @implements IteratorAggregate<int,InflectorDefinition>
  */
 final class InflectorConfig implements IteratorAggregate
 {
     /**
-     * @var array
+     * @var array<InflectorDefinition>
      */
-    private $inflectors;
+    private array $inflectors = [];
 
     /**
-     * @param array $config
+     * @param array<string,array<string,array<mixed>>> $config
      */
     public function __construct(array $config)
     {
-        $this->inflectors = [];
-
         foreach ($config as $interfaceName => $methods) {
             $this->inflectors[] = new InflectorDefinition(
                 $interfaceName,
@@ -30,7 +33,7 @@ final class InflectorConfig implements IteratorAggregate
         }
     }
 
-    public function getIterator()
+    public function getIterator(): Traversable
     {
         return new ArrayIterator($this->inflectors);
     }

--- a/src/InflectorDefinition.php
+++ b/src/InflectorDefinition.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace TomPHP\ContainerConfigurator;
 
 /**
@@ -8,37 +10,21 @@ namespace TomPHP\ContainerConfigurator;
 final class InflectorDefinition
 {
     /**
-     * @var string
+     * @param array<string,array<mixed>> $methods
      */
-    private $interface;
-
-    /**
-     * @var array
-     */
-    private $methods;
-
-    /**
-     * @param string $interface
-     * @param array  $methods
-     */
-    public function __construct($interface, array $methods)
+    public function __construct(private readonly string $interface, private readonly array $methods)
     {
-        $this->interface = $interface;
-        $this->methods   = $methods;
     }
 
-    /**
-     * @return string
-     */
-    public function getInterface()
+    public function getInterface(): string
     {
         return $this->interface;
     }
 
     /**
-     * @return array
+     * @return array<string,array<mixed>>
      */
-    public function getMethods()
+    public function getMethods(): array
     {
         return $this->methods;
     }

--- a/src/League/InflectorServiceProvider.php
+++ b/src/League/InflectorServiceProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace TomPHP\ContainerConfigurator\League;
 
 use League\Container\ServiceProvider\AbstractServiceProvider;
@@ -12,38 +14,35 @@ use TomPHP\ContainerConfigurator\InflectorDefinition;
  */
 final class InflectorServiceProvider extends AbstractServiceProvider implements BootableServiceProviderInterface
 {
-    /**
-     * @var InflectorConfig
-     */
-    private $config;
-
-    /**
-     * @param InflectorConfig $config
-     */
-    public function __construct(InflectorConfig $config)
-    {
-        $this->config = $config;
+    public function __construct(
+        /**
+         * @var InflectorConfig<int|string,InflectorDefinition>
+         */
+        private readonly \TomPHP\ContainerConfigurator\InflectorConfig $inflectorConfig
+    ) {
     }
 
-    public function register()
+    public function provides(string $id): bool
+    {
+        return false;
+    }
+
+    public function register(): void
     {
     }
 
-    public function boot()
+    public function boot(): void
     {
-        foreach ($this->config as $definition) {
+        foreach ($this->inflectorConfig as $definition) {
             $this->configureInterface($definition);
         }
     }
 
-    /**
-     * @param InflectorDefinition $definition
-     */
-    private function configureInterface(InflectorDefinition $definition)
+    private function configureInterface(InflectorDefinition $inflectorDefinition): void
     {
-        foreach ($definition->getMethods() as $method => $args) {
+        foreach ($inflectorDefinition->getMethods() as $method => $args) {
             $this->addInflectorMethod(
-                $definition->getInterface(),
+                $inflectorDefinition->getInterface(),
                 $method,
                 $args
             );
@@ -51,11 +50,9 @@ final class InflectorServiceProvider extends AbstractServiceProvider implements 
     }
 
     /**
-     * @param string $interface
-     * @param string $method
-     * @param array  $args
+     * @param array<mixed> $args
      */
-    private function addInflectorMethod($interface, $method, array $args)
+    private function addInflectorMethod(string $interface, string $method, array $args): void
     {
         $this->getContainer()
             ->inflector($interface)

--- a/src/League/LeagueContainerAdapter.php
+++ b/src/League/LeagueContainerAdapter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace TomPHP\ContainerConfigurator\League;
 
 use Assert\Assertion;
@@ -22,25 +24,25 @@ final class LeagueContainerAdapter implements ContainerAdapter
     /**
      * @param Container $container
      */
-    public function setContainer($container)
+    public function setContainer(object $container): void
     {
         $this->container = $container;
     }
 
-    public function addApplicationConfig(ApplicationConfig $config, $prefix = 'config')
+    public function addApplicationConfig(ApplicationConfig $applicationConfig, string $prefix = 'config'): void
     {
         Assertion::string($prefix);
 
-        $this->container->addServiceProvider(new ApplicationConfigServiceProvider($config, $prefix));
+        $this->container->addServiceProvider(new ApplicationConfigServiceProvider($applicationConfig, $prefix));
     }
 
-    public function addServiceConfig(ServiceConfig $config)
+    public function addServiceConfig(ServiceConfig $serviceConfig): void
     {
-        $this->container->addServiceProvider(new ServiceServiceProvider($config));
+        $this->container->addServiceProvider(new ServiceServiceProvider($serviceConfig));
     }
 
-    public function addInflectorConfig(InflectorConfig $config)
+    public function addInflectorConfig(InflectorConfig $inflectorConfig): void
     {
-        $this->container->addServiceProvider(new InflectorServiceProvider($config));
+        $this->container->addServiceProvider(new InflectorServiceProvider($inflectorConfig));
     }
 }

--- a/src/ServiceConfig.php
+++ b/src/ServiceConfig.php
@@ -1,29 +1,39 @@
 <?php
 
+declare(strict_types=1);
+
 namespace TomPHP\ContainerConfigurator;
 
 use ArrayIterator;
 use Assert\Assertion;
 use InvalidArgumentException;
 use IteratorAggregate;
+use Traversable;
 
 /**
  * @internal
+ *
+ * @implements IteratorAggregate<int,ServiceDefinition>
  */
 final class ServiceConfig implements IteratorAggregate
 {
     /**
      * @var ServiceDefinition[]
      */
-    private $config = [];
+    private array $config = [];
 
     /**
-     * @param array $config
-     * @param bool  $singletonDefault
+     * @param array<string,array{
+     *  singleton?:bool,
+     *  factory?:mixed,
+     *  service?:mixed,
+     *  arguments?:array<mixed>,
+     *  methods?:array<string,array<mixed>>
+     * }> $config
      *
      * @throws InvalidArgumentException
      */
-    public function __construct(array $config, $singletonDefault = false)
+    public function __construct(array $config, bool $singletonDefault = false)
     {
         Assertion::boolean($singletonDefault);
 
@@ -33,19 +43,17 @@ final class ServiceConfig implements IteratorAggregate
     }
 
     /**
-     * @return array
+     * @return array<int|string,string>
      */
-    public function getKeys()
+    public function getKeys(): array
     {
         return array_map(
-            function (ServiceDefinition $definition) {
-                return $definition->getName();
-            },
+            fn (ServiceDefinition $serviceDefinition): string => $serviceDefinition->getName(),
             $this->config
         );
     }
 
-    public function getIterator()
+    public function getIterator(): Traversable
     {
         return new ArrayIterator($this->config);
     }

--- a/src/ServiceDefinition.php
+++ b/src/ServiceDefinition.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace TomPHP\ContainerConfigurator;
 
 use Assert\Assertion;
@@ -11,128 +13,101 @@ use TomPHP\ContainerConfigurator\Exception\InvalidConfigException;
  */
 final class ServiceDefinition
 {
-    /**
-     * @var string
-     */
-    private $name;
+    private readonly string $name;
+
+    private readonly string $class;
+
+    private readonly bool $isSingleton;
+
+    private readonly bool $isFactory;
+
+    private readonly bool $isAlias;
 
     /**
-     * @var string
+     * @var array<mixed>
      */
-    private $class;
+    private readonly array $arguments;
 
     /**
-     * @var bool
+     * @var array<string,array<mixed>>
      */
-    private $isSingleton;
+    private readonly array $methods;
 
     /**
-     * @var bool
-     */
-    private $isFactory;
-
-    /**
-     * @var bool
-     */
-    private $isAlias;
-
-    /**
-     * @var array
-     */
-    private $arguments;
-
-    /**
-     * @var array
-     */
-    private $methods;
-
-    /**
-     * @param string $name
-     * @param array  $config
-     * @param bool   $singletonDefault
+     * @param array{
+     *  singleton?:bool,
+     *  factory?:mixed,
+     *  service?:mixed,
+     *  arguments?:array<mixed>,
+     *  methods?:array<string,
+     *  array<mixed>>
+     * } $config
      *
      * @throws InvalidArgumentException
      * @throws InvalidConfigException
      */
-    public function __construct($name, array $config, $singletonDefault = false)
+    public function __construct(string $name, array $config, bool $singletonDefault = false)
     {
         Assertion::string($name);
         Assertion::boolean($singletonDefault);
 
         $this->name        = $name;
         $this->class       = $this->className($name, $config);
-        $this->isSingleton = isset($config['singleton']) ? $config['singleton'] : $singletonDefault;
+        $this->isSingleton =
+            isset($config['singleton']) && is_bool($config['singleton']) ? $config['singleton'] : $singletonDefault;
         $this->isFactory   = isset($config['factory']);
         $this->isAlias     = isset($config['service']);
-        $this->arguments   = isset($config['arguments']) ? $config['arguments'] : [];
-        $this->methods     = isset($config['methods']) ? $config['methods'] : [];
+        $this->arguments   = isset($config['arguments']) && is_array($config['arguments']) ? $config['arguments'] : [];
+        $this->methods     = isset($config['methods']) && is_array($config['methods']) ? $config['methods'] : [];
     }
 
-    /**
-     * @return string
-     */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
 
-    /**
-     * @return string
-     */
-    public function getClass()
+    public function getClass(): string
     {
         return $this->class;
     }
 
-    /**
-     * @return bool
-     */
-    public function isSingleton()
+    public function isSingleton(): bool
     {
         return $this->isSingleton;
     }
 
-    /**
-     * @return bool
-     */
-    public function isFactory()
+    public function isFactory(): bool
     {
         return $this->isFactory;
     }
 
-    /**
-     * @return bool
-     */
-    public function isAlias()
+    public function isAlias(): bool
     {
         return $this->isAlias;
     }
 
     /**
-     * @return array
+     * @return array<mixed>
      */
-    public function getArguments()
+    public function getArguments(): array
     {
         return $this->arguments;
     }
 
     /**
-     * @return array
+     * @return array<string,array<mixed>>
      */
-    public function getMethods()
+    public function getMethods(): array
     {
         return $this->methods;
     }
 
     /**
-     * @param string $name
-     * @param array  $config
+     * @param array<string,mixed> $config
      *
      * @throws InvalidConfigException
-     *
-     * @return string
      */
-    private function className($name, array $config)
+    private function className(string $name, array $config): string
     {
         if (isset($config['class']) && isset($config['factory'])) {
             throw InvalidConfigException::fromNameWhenClassAndFactorySpecified($name);
@@ -146,15 +121,15 @@ final class ServiceDefinition
             throw InvalidConfigException::fromNameWhenFactoryAndServiceSpecified($name);
         }
 
-        if (isset($config['service'])) {
+        if (isset($config['service']) && is_string($config['service'])) {
             return $config['service'];
         }
 
-        if (isset($config['class'])) {
+        if (isset($config['class']) && is_string($config['class'])) {
             return $config['class'];
         }
 
-        if (isset($config['factory'])) {
+        if (isset($config['factory']) && is_string($config['factory'])) {
             return $config['factory'];
         }
 

--- a/tests/acceptance/AbstractContainerAdapterTest.php
+++ b/tests/acceptance/AbstractContainerAdapterTest.php
@@ -1,13 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace tests\acceptance;
 
 use Interop\Container\ContainerInterface;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use tests\support\TestFileCreator;
 use TomPHP\ContainerConfigurator\Configurator;
 
-abstract class AbstractContainerAdapterTest extends PHPUnit_Framework_TestCase
+abstract class AbstractContainerAdapterTest extends TestCase
 {
     use SupportsApplicationConfig;
     use SupportsServiceConfig;
@@ -19,7 +21,7 @@ abstract class AbstractContainerAdapterTest extends PHPUnit_Framework_TestCase
      */
     protected $container;
 
-    public function testItCanBeConfiguredFromAFile()
+    public function testItCanBeConfiguredFromAFile(): void
     {
         $config = ['example-key' => 'example-value'];
 
@@ -29,10 +31,10 @@ abstract class AbstractContainerAdapterTest extends PHPUnit_Framework_TestCase
             ->configFromFile($this->getTestPath('config.json'))
             ->to($this->container);
 
-        assertSame('example-value', $this->container->get('config.example-key'));
+        $this->assertSame('example-value', $this->container->get('config.example-key'));
     }
 
-    public function testItCanBeConfiguredFromFiles()
+    public function testItCanBeConfiguredFromFiles(): void
     {
         $config = ['example-key' => 'example-value'];
 
@@ -42,10 +44,10 @@ abstract class AbstractContainerAdapterTest extends PHPUnit_Framework_TestCase
             ->configFromFiles($this->getTestPath('*'))
             ->to($this->container);
 
-        assertSame('example-value', $this->container->get('config.example-key'));
+        $this->assertSame('example-value', $this->container->get('config.example-key'));
     }
 
-    public function testItAddToConfigUsingFiles()
+    public function testItAddToConfigUsingFiles(): void
     {
         $config = ['keyB' => 'valueB'];
 
@@ -56,7 +58,7 @@ abstract class AbstractContainerAdapterTest extends PHPUnit_Framework_TestCase
             ->configFromFiles($this->getTestPath('*'))
             ->to($this->container);
 
-        assertSame('valueA', $this->container->get('config.keyA'));
-        assertSame('valueB', $this->container->get('config.keyB'));
+        $this->assertSame('valueA', $this->container->get('config.keyA'));
+        $this->assertSame('valueB', $this->container->get('config.keyB'));
     }
 }

--- a/tests/acceptance/LeagueContainerAdapterTest.php
+++ b/tests/acceptance/LeagueContainerAdapterTest.php
@@ -1,12 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace tests\acceptance;
 
 use League\Container\Container;
 
 final class LeagueContainerAdapterTest extends AbstractContainerAdapterTest
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->container = new Container();
     }

--- a/tests/acceptance/PimpleContainerAdapterTest.php
+++ b/tests/acceptance/PimpleContainerAdapterTest.php
@@ -1,10 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace tests\acceptance;
 
 final class PimpleContainerAdapterTest extends AbstractContainerAdapterTest
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->container = new PimpleContainerWrapper();
     }

--- a/tests/acceptance/PimpleContainerWrapper.php
+++ b/tests/acceptance/PimpleContainerWrapper.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace tests\acceptance;
 
 use Pimple\Container;
@@ -11,7 +13,7 @@ final class PimpleContainerWrapper extends Container
         return $this[$id];
     }
 
-    public function has($id)
+    public function has($id): bool
     {
         return isset($this[$id]);
     }

--- a/tests/acceptance/SupportsApplicationConfig.php
+++ b/tests/acceptance/SupportsApplicationConfig.php
@@ -1,12 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace tests\acceptance;
 
 use TomPHP\ContainerConfigurator\Configurator;
 
 trait SupportsApplicationConfig
 {
-    public function testItAddsConfigToTheContainer()
+    public function testItAddsConfigToTheContainer(): void
     {
         $config = ['keyA' => 'valueA'];
 
@@ -14,56 +16,60 @@ trait SupportsApplicationConfig
             ->configFromArray($config)
             ->to($this->container);
 
-        assertEquals('valueA', $this->container->get('config.keyA'));
+        $this->assertEquals('valueA', $this->container->get('config.keyA'));
+        $this->assertIsArray($this->container->get('config'));
+        $this->assertArrayHasKey('keyA', $this->container->get('config'));
     }
 
-    public function testItCascadeAddsConfigToTheContainer()
+    public function testItCascadeAddsConfigToTheContainer(): void
     {
         Configurator::apply()
             ->configFromArray(['keyA' => 'valueA', 'keyB' => 'valueX'])
             ->configFromArray(['keyB' => 'valueB'])
             ->to($this->container);
 
-        assertEquals('valueA', $this->container->get('config.keyA'));
+        $this->assertEquals('valueA', $this->container->get('config.keyA'));
     }
 
-    public function testItAddsGroupedConfigToTheContainer()
+    public function testItAddsGroupedConfigToTheContainer(): void
     {
         Configurator::apply()
             ->configFromArray(['group1' => ['keyA' => 'valueA']])
             ->to($this->container);
 
-        assertEquals(['keyA' => 'valueA'], $this->container->get('config.group1'));
-        assertEquals('valueA', $this->container->get('config.group1.keyA'));
+        $this->assertEquals(['keyA' => 'valueA'], $this->container->get('config.group1'));
+        $this->assertEquals('valueA', $this->container->get('config.group1.keyA'));
     }
 
-    public function testItAddsConfigToTheContainerWithAnAlternativeSeparator()
+    public function testItAddsConfigToTheContainerWithAnAlternativeSeparator(): void
     {
         Configurator::apply()
             ->configFromArray(['keyA' => 'valueA'])
             ->withSetting(Configurator::SETTING_SEPARATOR, '/')
             ->to($this->container);
 
-        assertEquals('valueA', $this->container->get('config/keyA'));
+        $this->assertEquals('valueA', $this->container->get('config/keyA'));
     }
 
-    public function testItAddsConfigToTheContainerWithAnAlternativePrefix()
+    public function testItAddsConfigToTheContainerWithAnAlternativePrefix(): void
     {
         Configurator::apply()
             ->configFromArray(['keyA' => 'valueA'])
             ->withSetting(Configurator::SETTING_PREFIX, 'settings')
             ->to($this->container);
 
-        assertEquals('valueA', $this->container->get('settings.keyA'));
+        $this->assertEquals('valueA', $this->container->get('settings.keyA'));
+        $this->assertIsArray($this->container->get('settings'));
+        $this->assertArrayHasKey('keyA', $this->container->get('settings'));
     }
 
-    public function testItAddsConfigToTheContainerWithNoPrefix()
+    public function testItAddsConfigToTheContainerWithNoPrefix(): void
     {
         Configurator::apply()
             ->configFromArray(['keyA' => 'valueA'])
             ->withSetting(Configurator::SETTING_PREFIX, '')
             ->to($this->container);
 
-        assertEquals('valueA', $this->container->get('keyA'));
+        $this->assertEquals('valueA', $this->container->get('keyA'));
     }
 }

--- a/tests/acceptance/SupportsInflectorConfig.php
+++ b/tests/acceptance/SupportsInflectorConfig.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace tests\acceptance;
 
 use tests\mocks\ExampleClass;
@@ -9,7 +11,7 @@ use TomPHP\ContainerConfigurator\Configurator;
 
 trait SupportsInflectorConfig
 {
-    public function testItSetsUpAnInflectorForClassNameFactory()
+    public function testItSetsUpAnInflectorForClassNameFactory(): void
     {
         $config = [
             'di' => [
@@ -30,13 +32,13 @@ trait SupportsInflectorConfig
             ->configFromArray($config)
             ->to($this->container);
 
-        assertEquals(
+        $this->assertEquals(
             'test_value',
             $this->container->get('example')->getValue()
         );
     }
 
-    public function testItSetsUpAnInflectorForServiceFactory()
+    public function testItSetsUpAnInflectorForServiceFactory(): void
     {
         $config = [
             'class_name' => ExampleClass::class,
@@ -61,13 +63,13 @@ trait SupportsInflectorConfig
             ->configFromArray($config)
             ->to($this->container);
 
-        assertEquals(
+        $this->assertEquals(
             'test_value',
             $this->container->get('example')->getValue()
         );
     }
 
-    public function testItResolvesInflectorArguments()
+    public function testItResolvesInflectorArguments(): void
     {
         $config = [
             'argument' => 'test_value',
@@ -89,13 +91,13 @@ trait SupportsInflectorConfig
             ->configFromArray($config)
             ->to($this->container);
 
-        assertEquals(
+        $this->assertEquals(
             'test_value',
             $this->container->get('example')->getValue()
         );
     }
 
-    public function testItSetsUpAnInflectorUsingCustomInflectorsKey()
+    public function testItSetsUpAnInflectorUsingCustomInflectorsKey(): void
     {
         $config = [
             'di' => [
@@ -117,7 +119,7 @@ trait SupportsInflectorConfig
             ->withSetting(Configurator::SETTING_INFLECTORS_KEY, 'inflectors')
             ->to($this->container);
 
-        assertEquals(
+        $this->assertEquals(
             'test_value',
             $this->container->get('example')->getValue()
         );

--- a/tests/acceptance/SupportsServiceConfig.php
+++ b/tests/acceptance/SupportsServiceConfig.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace tests\acceptance;
 
 use tests\mocks\ExampleClass;
@@ -9,7 +11,7 @@ use TomPHP\ContainerConfigurator\Configurator;
 
 trait SupportsServiceConfig
 {
-    public function testItAddsServicesToTheContainer()
+    public function testItAddsServicesToTheContainer(): void
     {
         $config = [
             'di' => [
@@ -25,10 +27,10 @@ trait SupportsServiceConfig
             ->configFromArray($config)
             ->to($this->container);
 
-        assertInstanceOf(ExampleClass::class, $this->container->get('example_class'));
+        $this->assertInstanceOf(ExampleClass::class, $this->container->get('example_class'));
     }
 
-    public function testItAddsServicesToTheContainerForADifferentConfigKey()
+    public function testItAddsServicesToTheContainerForADifferentConfigKey(): void
     {
         $config = [
             'di' => [
@@ -43,10 +45,10 @@ trait SupportsServiceConfig
             ->withSetting(Configurator::SETTING_SERVICES_KEY, 'di')
             ->to($this->container);
 
-        assertInstanceOf(ExampleClass::class, $this->container->get('example_class'));
+        $this->assertInstanceOf(ExampleClass::class, $this->container->get('example_class'));
     }
 
-    public function testItCreatesUniqueServiceInstancesByDefault()
+    public function testItCreatesUniqueServiceInstancesByDefault(): void
     {
         $config = [
             'di' => [
@@ -66,10 +68,10 @@ trait SupportsServiceConfig
         $instance1 = $this->container->get('example_class');
         $instance2 = $this->container->get('example_class');
 
-        assertNotSame($instance1, $instance2);
+        $this->assertNotSame($instance1, $instance2);
     }
 
-    public function testItCanCreateSingletonServiceInstances()
+    public function testItCanCreateSingletonServiceInstances(): void
     {
         $config = [
             'di' => [
@@ -89,10 +91,10 @@ trait SupportsServiceConfig
         $instance1 = $this->container->get('example_class');
         $instance2 = $this->container->get('example_class');
 
-        assertSame($instance1, $instance2);
+        $this->assertSame($instance1, $instance2);
     }
 
-    public function testItCanCreateSingletonServiceInstancesByDefault()
+    public function testItCanCreateSingletonServiceInstancesByDefault(): void
     {
         $config = [
             'di' => [
@@ -112,10 +114,10 @@ trait SupportsServiceConfig
         $instance1 = $this->container->get('example_class');
         $instance2 = $this->container->get('example_class');
 
-        assertSame($instance1, $instance2);
+        $this->assertSame($instance1, $instance2);
     }
 
-    public function testItCanCreateUniqueServiceInstancesWhenSingletonIsDefault()
+    public function testItCanCreateUniqueServiceInstancesWhenSingletonIsDefault(): void
     {
         $config = [
             'di' => [
@@ -136,10 +138,10 @@ trait SupportsServiceConfig
         $instance1 = $this->container->get('example_class');
         $instance2 = $this->container->get('example_class');
 
-        assertNotSame($instance1, $instance2);
+        $this->assertNotSame($instance1, $instance2);
     }
 
-    public function testItAddsConstructorArguments()
+    public function testItAddsConstructorArguments(): void
     {
         $config = [
             'di' => [
@@ -161,10 +163,10 @@ trait SupportsServiceConfig
 
         $instance = $this->container->get('example_class');
 
-        assertEquals(['arg1', 'arg2'], $instance->getConstructorArgs());
+        $this->assertEquals(['arg1', 'arg2'], $instance->getConstructorArgs());
     }
 
-    public function testItResolvesConstructorArgumentsIfTheyAreServiceNames()
+    public function testItResolvesConstructorArgumentsIfTheyAreServiceNames(): void
     {
         $config = [
             'arg1' => 'value1',
@@ -188,10 +190,10 @@ trait SupportsServiceConfig
 
         $instance = $this->container->get('example_class');
 
-        assertEquals(['value1', 'value2'], $instance->getConstructorArgs());
+        $this->assertEquals(['value1', 'value2'], $instance->getConstructorArgs());
     }
 
-    public function testItUsesTheStringIfConstructorArgumentsAreClassNames()
+    public function testItUsesTheStringIfConstructorArgumentsAreClassNames(): void
     {
         $config = [
             'di' => [
@@ -213,10 +215,10 @@ trait SupportsServiceConfig
 
         $instance = $this->container->get('example_class');
 
-        assertEquals([ExampleClass::class, 'arg2'], $instance->getConstructorArgs());
+        $this->assertEquals([ExampleClass::class, 'arg2'], $instance->getConstructorArgs());
     }
 
-    public function testItUsesComplexConstructorArguments()
+    public function testItUsesComplexConstructorArguments(): void
     {
         $config = [
             'di' => [
@@ -238,10 +240,10 @@ trait SupportsServiceConfig
 
         $instance = $this->container->get('example_class');
 
-        assertEquals([['example_array'], new \stdClass()], $instance->getConstructorArgs());
+        $this->assertEquals([['example_array'], new \stdClass()], $instance->getConstructorArgs());
     }
 
-    public function testItCallsSetterMethods()
+    public function testItCallsSetterMethods(): void
     {
         $config = [
             'di' => [
@@ -262,10 +264,10 @@ trait SupportsServiceConfig
 
         $instance = $this->container->get('example_class');
 
-        assertEquals('the value', $instance->getValue());
+        $this->assertEquals('the value', $instance->getValue());
     }
 
-    public function testItResolvesSetterMethodArgumentsIfTheyAreServiceNames()
+    public function testItResolvesSetterMethodArgumentsIfTheyAreServiceNames(): void
     {
         $config = [
             'arg' => 'value',
@@ -287,10 +289,10 @@ trait SupportsServiceConfig
 
         $instance = $this->container->get('example_class');
 
-        assertEquals('value', $instance->getValue());
+        $this->assertEquals('value', $instance->getValue());
     }
 
-    public function testItUsesTheStringIffSetterMethodArgumentsAreClassNames()
+    public function testItUsesTheStringIffSetterMethodArgumentsAreClassNames(): void
     {
         $config = [
             'di' => [
@@ -311,10 +313,10 @@ trait SupportsServiceConfig
 
         $instance = $this->container->get('example_class');
 
-        assertSame(ExampleClass::class, $instance->getValue());
+        $this->assertSame(ExampleClass::class, $instance->getValue());
     }
 
-    public function testIsCreatesAServiceThroughAFactoryClass()
+    public function testIsCreatesAServiceThroughAFactoryClass(): void
     {
         $config = [
             'class_name' => ExampleClassWithArgs::class,
@@ -337,11 +339,11 @@ trait SupportsServiceConfig
 
         $instance = $this->container->get('example_service');
 
-        assertInstanceOf(ExampleClassWithArgs::class, $instance);
-        assertSame(['example_argument'], $instance->getConstructorArgs());
+        $this->assertInstanceOf(ExampleClassWithArgs::class, $instance);
+        $this->assertSame(['example_argument'], $instance->getConstructorArgs());
     }
 
-    public function testItCanCreateAServiceAlias()
+    public function testItCanCreateAServiceAlias(): void
     {
         $config = [
             'di' => [
@@ -361,10 +363,10 @@ trait SupportsServiceConfig
             ->configFromArray($config)
             ->to($this->container);
 
-        assertSame($this->container->get('example_class'), $this->container->get('example_alias'));
+        $this->assertSame($this->container->get('example_class'), $this->container->get('example_alias'));
     }
 
-    public function testItInjectsTheContainerAsAConstructorDependency()
+    public function testItInjectsTheContainerAsAConstructorDependency(): void
     {
         $config = [
             'di' => [
@@ -383,10 +385,10 @@ trait SupportsServiceConfig
 
         $instance = $this->container->get('example_service');
 
-        assertSame([$this->container], $instance->getConstructorArgs());
+        $this->assertSame([$this->container], $instance->getConstructorArgs());
     }
 
-    public function testItInjectsTheContainerAsAMethodDependency()
+    public function testItInjectsTheContainerAsAMethodDependency(): void
     {
         $config = [
             'di' => [
@@ -407,10 +409,10 @@ trait SupportsServiceConfig
 
         $instance = $this->container->get('example_service');
 
-        assertSame($this->container, $instance->getValue());
+        $this->assertSame($this->container, $instance->getValue());
     }
 
-    public function testItInjectsTheContainerAsFactoryDependency()
+    public function testItInjectsTheContainerAsFactoryDependency(): void
     {
         $config = [
             'class_name' => ExampleClassWithArgs::class,
@@ -433,6 +435,6 @@ trait SupportsServiceConfig
 
         $instance = $this->container->get('example_service');
 
-        assertSame([$this->container], $instance->getConstructorArgs());
+        $this->assertSame([$this->container], $instance->getConstructorArgs());
     }
 }

--- a/tests/mocks/BootableServiceProvider.php
+++ b/tests/mocks/BootableServiceProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace tests\mocks;
 
 use League\Container\ServiceProvider\BootableServiceProviderInterface;

--- a/tests/mocks/ExampleClass.php
+++ b/tests/mocks/ExampleClass.php
@@ -1,12 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace tests\mocks;
 
 final class ExampleClass implements ExampleInterface
 {
     private $value;
 
-    public function setValue($value)
+    public function setValue($value): void
     {
         $this->value = $value;
     }

--- a/tests/mocks/ExampleClassWithArgs.php
+++ b/tests/mocks/ExampleClassWithArgs.php
@@ -1,17 +1,19 @@
 <?php
 
+declare(strict_types=1);
+
 namespace tests\mocks;
 
 final class ExampleClassWithArgs
 {
-    private $constructorArgs = [];
+    private array $constructorArgs = [];
 
     public function __construct(...$constructorArgs)
     {
         $this->constructorArgs = $constructorArgs;
     }
 
-    public function getConstructorArgs()
+    public function getConstructorArgs(): array
     {
         return $this->constructorArgs;
     }

--- a/tests/mocks/ExampleContainer.php
+++ b/tests/mocks/ExampleContainer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace tests\mocks;
 
 class ExampleContainer

--- a/tests/mocks/ExampleContainerAdapter.php
+++ b/tests/mocks/ExampleContainerAdapter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace tests\mocks;
 
 use TomPHP\ContainerConfigurator\ApplicationConfig;
@@ -9,44 +11,44 @@ use TomPHP\ContainerConfigurator\ServiceConfig;
 
 final class ExampleContainerAdapter implements ContainerAdapter
 {
-    private static $instanceCount = 0;
+    private static int $instanceCount = 0;
 
-    private $container;
+    private ?object $container = null;
 
     public function __construct()
     {
         self::$instanceCount++;
     }
 
-    public static function reset()
+    public static function reset(): void
     {
         self::$instanceCount = 0;
     }
 
-    public static function getNumberOfInstances()
+    public static function getNumberOfInstances(): int
     {
         return self::$instanceCount;
     }
 
-    public function setContainer($container)
+    public function setContainer(object $container): void
     {
         $this->container = $container;
     }
 
-    public function getContainer()
+    public function getContainer(): ?object
     {
         return $this->container;
     }
 
-    public function addApplicationConfig(ApplicationConfig $config, $prefix = 'config')
+    public function addApplicationConfig(ApplicationConfig $applicationConfig, string $prefix = 'config'): void
     {
     }
 
-    public function addServiceConfig(ServiceConfig $config)
+    public function addServiceConfig(ServiceConfig $serviceConfig): void
     {
     }
 
-    public function addInflectorConfig(InflectorConfig $config)
+    public function addInflectorConfig(InflectorConfig $inflectorConfig): void
     {
     }
 }

--- a/tests/mocks/ExampleExtendedContainer.php
+++ b/tests/mocks/ExampleExtendedContainer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace tests\mocks;
 
 final class ExampleExtendedContainer extends ExampleContainer

--- a/tests/mocks/ExampleFactory.php
+++ b/tests/mocks/ExampleFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace tests\mocks;
 
 final class ExampleFactory

--- a/tests/mocks/ExampleInterface.php
+++ b/tests/mocks/ExampleInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace tests\mocks;
 
 interface ExampleInterface

--- a/tests/mocks/FileReader/CustomFileReader.php
+++ b/tests/mocks/FileReader/CustomFileReader.php
@@ -1,24 +1,26 @@
 <?php
 
+declare(strict_types=1);
+
 namespace tests\mocks\FileReader;
 
 use TomPHP\ContainerConfigurator\FileReader\FileReader;
 
 final class CustomFileReader implements FileReader
 {
-    private static $reads = [];
+    private static array $reads = [];
 
-    public static function reset()
+    public static function reset(): void
     {
         self::$reads = [];
     }
 
-    public static function getReads()
+    public static function getReads(): array
     {
         return self::$reads;
     }
 
-    public function read($filename)
+    public function read(string $filename): mixed
     {
         self::$reads[] = $filename;
 

--- a/tests/mocks/NotContainerAdapter.php
+++ b/tests/mocks/NotContainerAdapter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace tests\mocks;
 
 final class NotContainerAdapter

--- a/tests/support/TestFileCreator.php
+++ b/tests/support/TestFileCreator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace tests\support;
 
 trait TestFileCreator
@@ -9,26 +11,23 @@ trait TestFileCreator
      */
     private $configFilePath;
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->deleteTestFiles();
     }
 
     /**
      * @param string $name
-     *
-     * @return string
      */
-    protected function getTestPath($name)
+    protected function getTestPath($name): string
     {
         $this->ensurePathExists();
 
-        return "{$this->configFilePath}/$name";
+        return sprintf('%s/%s', $this->configFilePath, $name);
     }
 
     /**
      * @param string $filename
-     * @param array  $config
      */
     protected function createPHPConfigFile($filename, array $config)
     {
@@ -39,7 +38,6 @@ trait TestFileCreator
 
     /**
      * @param string $filename
-     * @param array  $config
      */
     protected function createJSONConfigFile($filename, array $config)
     {
@@ -56,26 +54,26 @@ trait TestFileCreator
     {
         $this->ensurePathExists();
 
-        file_put_contents("{$this->configFilePath}/$name", $content);
+        file_put_contents(sprintf('%s/%s', $this->configFilePath, $name), $content);
     }
 
-    private function deleteTestFiles()
+    private function deleteTestFiles(): void
     {
         $this->ensurePathExists();
 
         // Test for safety!
-        if (strpos($this->configFilePath, __DIR__) !== 0) {
+        if (!str_starts_with($this->configFilePath, __DIR__)) {
             throw new \Exception('DANGER!!! - Config file is not local to this project');
         }
 
-        $files = glob("{$this->configFilePath}/*");
+        $files = glob($this->configFilePath . '/*');
 
         foreach ($files as $file) {
             unlink($file);
         }
     }
 
-    private function ensurePathExists()
+    private function ensurePathExists(): void
     {
         $this->configFilePath = __DIR__ . '/../.test-config';
 

--- a/tests/unit/ApplicationConfigIteratorTest.php
+++ b/tests/unit/ApplicationConfigIteratorTest.php
@@ -1,31 +1,33 @@
 <?php
 
+declare(strict_types=1);
+
 namespace tests\unit\TomPHP\ContainerConfigurator;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use TomPHP\ContainerConfigurator\ApplicationConfig;
 
-final class ApplicationConfigIteratorTest extends PHPUnit_Framework_TestCase
+final class ApplicationConfigIteratorTest extends TestCase
 {
-    public function testItIteratesOverSimpleConfigValues()
+    public function testItIteratesOverSimpleConfigValues(): void
     {
-        $iterator = new ApplicationConfig([
+        $applicationConfig = new ApplicationConfig([
             'keyA'   => 'valueA',
             'keyB'   => 'valueB',
         ]);
 
-        assertEquals(
+        $this->assertSame(
             [
                 'keyA'   => 'valueA',
                 'keyB'   => 'valueB',
             ],
-            iterator_to_array($iterator)
+            iterator_to_array($applicationConfig)
         );
     }
 
-    public function testItIteratesRecursively()
+    public function testItIteratesRecursively(): void
     {
-        $iterator = new ApplicationConfig([
+        $applicationConfig = new ApplicationConfig([
             'group1' => [
                 'keyA'   => 'valueA',
             ],
@@ -34,7 +36,7 @@ final class ApplicationConfigIteratorTest extends PHPUnit_Framework_TestCase
             ],
         ]);
 
-        assertEquals(
+        $this->assertSame(
             [
                 'group1' => [
                     'keyA' => 'valueA',
@@ -45,13 +47,13 @@ final class ApplicationConfigIteratorTest extends PHPUnit_Framework_TestCase
                 ],
                 'group2.keyB' => 'valueB',
             ],
-            iterator_to_array($iterator)
+            iterator_to_array($applicationConfig)
         );
     }
 
-    public function testItGoesMultipleLevels()
+    public function testItGoesMultipleLevels(): void
     {
-        $iterator = new ApplicationConfig([
+        $applicationConfig = new ApplicationConfig([
             'group1' => [
                 'keyA'   => 'valueA',
                 'group2' => [
@@ -60,7 +62,7 @@ final class ApplicationConfigIteratorTest extends PHPUnit_Framework_TestCase
             ],
         ]);
 
-        assertEquals(
+        $this->assertSame(
             [
                 'group1' => [
                     'keyA'   => 'valueA',
@@ -74,13 +76,13 @@ final class ApplicationConfigIteratorTest extends PHPUnit_Framework_TestCase
                 ],
                 'group1.group2.keyB' => 'valueB',
             ],
-            iterator_to_array($iterator)
+            iterator_to_array($applicationConfig)
         );
     }
 
-    public function testItRewinds()
+    public function testItRewinds(): void
     {
-        $iterator = new ApplicationConfig([
+        $applicationConfig = new ApplicationConfig([
             'group1' => [
                 'keyA'   => 'valueA',
                 'keyB'   => 'valueB',
@@ -88,11 +90,11 @@ final class ApplicationConfigIteratorTest extends PHPUnit_Framework_TestCase
             ],
         ]);
 
-        next($iterator);
-        next($iterator);
-        next($iterator);
+        $applicationConfig->getIterator()->next();
+        $applicationConfig->getIterator()->next();
+        $applicationConfig->getIterator()->next();
 
-        assertEquals(
+        $this->assertSame(
             [
                 'group1' => [
                     'keyA'   => 'valueA',
@@ -103,26 +105,26 @@ final class ApplicationConfigIteratorTest extends PHPUnit_Framework_TestCase
                 'group1.keyB' => 'valueB',
                 'group1.keyC' => 'valueC',
             ],
-            iterator_to_array($iterator)
+            iterator_to_array($applicationConfig)
         );
     }
 
-    public function testItUsesADifferentSeparator()
+    public function testItUsesADifferentSeparator(): void
     {
-        $iterator = new ApplicationConfig([
+        $applicationConfig = new ApplicationConfig([
             'group1' => [
                 'keyA'   => 'valueA',
             ],
         ], '->');
 
-        assertEquals(
+        $this->assertSame(
             [
                 'group1' => [
                     'keyA' => 'valueA',
                 ],
                 'group1->keyA' => 'valueA',
             ],
-            iterator_to_array($iterator)
+            iterator_to_array($applicationConfig)
         );
     }
 }

--- a/tests/unit/ApplicationConfigTest.php
+++ b/tests/unit/ApplicationConfigTest.php
@@ -1,23 +1,22 @@
 <?php
 
+declare(strict_types=1);
+
 namespace tests\unit\TomPHP\ContainerConfigurator;
 
 use InvalidArgumentException;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use tests\support\TestFileCreator;
 use TomPHP\ContainerConfigurator\ApplicationConfig;
 use TomPHP\ContainerConfigurator\Exception\ReadOnlyException;
 
-final class ApplicationConfigTest extends PHPUnit_Framework_TestCase
+final class ApplicationConfigTest extends TestCase
 {
     use TestFileCreator;
 
-    /**
-     * @var ApplicationConfig
-     */
-    private $config;
+    private \TomPHP\ContainerConfigurator\ApplicationConfig|array $config;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->config = new ApplicationConfig([
             'keyA'   => 'valueA',
@@ -28,39 +27,39 @@ final class ApplicationConfigTest extends PHPUnit_Framework_TestCase
         ]);
     }
 
-    public function testItProvidesAccessToSimpleScalarValues()
+    public function testItProvidesAccessToSimpleScalarValues(): void
     {
-        assertEquals('valueA', $this->config['keyA']);
+        $this->assertEquals('valueA', $this->config['keyA']);
     }
 
-    public function testItProvidesAccessToArrayValues()
+    public function testItProvidesAccessToArrayValues(): void
     {
-        assertEquals(['keyB' => 'valueB', 'null' => null], $this->config['group1']);
+        $this->assertEquals(['keyB' => 'valueB', 'null' => null], $this->config['group1']);
     }
 
-    public function testItProvidesToSubValuesUsingDotNotation()
+    public function testItProvidesToSubValuesUsingDotNotation(): void
     {
-        assertEquals('valueB', $this->config['group1.keyB']);
+        $this->assertEquals('valueB', $this->config['group1.keyB']);
     }
 
-    public function testItSaysIfAnEntryIsSet()
+    public function testItSaysIfAnEntryIsSet(): void
     {
-        assertTrue(isset($this->config['group1.keyB']));
+        $this->assertArrayHasKey('group1.keyB', $this->config);
     }
 
-    public function testItSaysIfAnEntryIsNotSet()
+    public function testItSaysIfAnEntryIsNotSet(): void
     {
-        assertFalse(isset($this->config['bad.entry']));
+        $this->assertArrayNotHasKey('bad.entry', $this->config);
     }
 
-    public function testItSaysIfAnEntryIsSetIfItIsFalsey()
+    public function testItSaysIfAnEntryIsSetIfItIsFalsey(): void
     {
-        assertTrue(isset($this->config['group1.null']));
+        $this->assertArrayHasKey('group1.null', $this->config);
     }
 
-    public function testItReturnsAllItsKeys()
+    public function testItReturnsAllItsKeys(): void
     {
-        assertEquals(
+        $this->assertSame(
             [
                 'keyA',
                 'group1',
@@ -71,9 +70,9 @@ final class ApplicationConfigTest extends PHPUnit_Framework_TestCase
         );
     }
 
-    public function testItCanBeConvertedToAnArray()
+    public function testItCanBeConvertedToAnArray(): void
     {
-        assertEquals(
+        $this->assertEquals(
             [
                 'keyA'   => 'valueA',
                 'group1' => [
@@ -85,66 +84,66 @@ final class ApplicationConfigTest extends PHPUnit_Framework_TestCase
         );
     }
 
-    public function testItWorksWithADifferentSeperator()
+    public function testItWorksWithADifferentSeperator(): void
     {
         $this->config = new ApplicationConfig([
             'group1' => [
                 'keyA' => 'valueA',
             ],
         ], '->');
-        assertEquals('valueA', $this->config['group1->keyA']);
+        $this->assertEquals('valueA', $this->config['group1->keyA']);
     }
 
-    public function testItThrowsForAnEmptySeparatorOnConstruction()
+    public function testItThrowsForAnEmptySeparatorOnConstruction(): void
     {
         $this->expectException(InvalidArgumentException::class);
 
         $this->config = new ApplicationConfig([], '');
     }
 
-    public function testItCannotHaveAValueSet()
+    public function testItCannotHaveAValueSet(): void
     {
         $this->expectException(ReadOnlyException::class);
 
         $this->config['key'] = 'value';
     }
 
-    public function testItCannotHaveAValueRemoved()
+    public function testItCannotHaveAValueRemoved(): void
     {
         $this->expectException(ReadOnlyException::class);
 
         unset($this->config['keyA']);
     }
 
-    public function testItMergesInNewConfig()
+    public function testItMergesInNewConfig(): void
     {
-        $config = new ApplicationConfig([
+        $applicationConfig = new ApplicationConfig([
             'group' => [
                 'keyA' => 'valueA',
                 'keyB' => 'valueX',
             ],
         ]);
 
-        $config->merge(['group' => ['keyB' => 'valueB']]);
+        $applicationConfig->merge(['group' => ['keyB' => 'valueB']]);
 
-        assertSame('valueA', $config['group.keyA']);
-        assertSame('valueB', $config['group.keyB']);
+        $this->assertSame('valueA', $applicationConfig['group.keyA']);
+        $this->assertSame('valueB', $applicationConfig['group.keyB']);
     }
 
-    public function testItUpdatesTheSeparator()
+    public function testItUpdatesTheSeparator(): void
     {
-        $config = new ApplicationConfig([
+        $applicationConfig = new ApplicationConfig([
             'group' => [
                 'keyA' => 'valueA',
             ],
         ]);
 
-        $config->setSeparator('/');
+        $applicationConfig->setSeparator('/');
 
-        assertSame('valueA', $config['group/keyA']);
+        $this->assertSame('valueA', $applicationConfig['group/keyA']);
     }
 
-    public function testItThrowsForAnEmptySeparatorWhenSettingSeparator()
+    public function testItThrowsForAnEmptySeparatorWhenSettingSeparator(): void
     {
         $this->expectException(InvalidArgumentException::class);
 

--- a/tests/unit/ConfiguratorTest.php
+++ b/tests/unit/ConfiguratorTest.php
@@ -1,9 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace tests\unit\TomPHP\ContainerConfigurator;
 
 use InvalidArgumentException;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Pimple\Container;
 use tests\mocks\ExampleContainer;
 use tests\mocks\ExampleContainerAdapter;
@@ -13,37 +15,37 @@ use TomPHP\ContainerConfigurator\Configurator;
 use TomPHP\ContainerConfigurator\Exception\NoMatchingFilesException;
 use TomPHP\ContainerConfigurator\Exception\UnknownSettingException;
 
-final class ConfiguratorTest extends PHPUnit_Framework_TestCase
+final class ConfiguratorTest extends TestCase
 {
     use TestFileCreator;
 
-    public function testItThrowsAnExceptionWhenTheFileIsNotFound()
+    public function testItThrowsAnExceptionWhenTheFileIsNotFound(): void
     {
         $this->expectException(InvalidArgumentException::class);
 
         Configurator::apply()->configFromFile($this->getTestPath('config.php'));
     }
 
-    public function testItThrowsAnExceptionWhenNoFilesAreNotFound()
+    public function testItThrowsAnExceptionWhenNoFilesAreNotFound(): void
     {
         $this->expectException(NoMatchingFilesException::class);
 
         Configurator::apply()->configFromFiles($this->getTestPath('config.php'));
     }
 
-    public function testItThrowsWhenAnUnknownSettingIsSet()
+    public function testItThrowsWhenAnUnknownSettingIsSet(): void
     {
         $this->expectException(UnknownSettingException::class);
 
         Configurator::apply()->withSetting('unknown_setting', 'value');
     }
 
-    public function testTheContainerIdentifierStringIsAlwaysTheSame()
+    public function testTheContainerIdentifierStringIsAlwaysTheSame(): void
     {
-        assertSame(Configurator::container(), Configurator::container());
+        $this->assertSame(Configurator::container(), Configurator::container());
     }
 
-    public function testItCanAcceptADifferentFileReader()
+    public function testItCanAcceptADifferentFileReader(): void
     {
         $container = new Container();
         $this->createTestFile('custom.xxx');
@@ -55,19 +57,19 @@ final class ConfiguratorTest extends PHPUnit_Framework_TestCase
             ->configFromFile($configFile)
             ->to($container);
 
-        assertSame([$configFile], CustomFileReader::getReads());
+        $this->assertSame([$configFile], CustomFileReader::getReads());
     }
 
-    public function testItCanUseDifferentContainerAdapters()
+    public function testItCanUseDifferentContainerAdapters(): void
     {
-        $container = new ExampleContainer();
+        $exampleContainer = new ExampleContainer();
         ExampleContainerAdapter::reset();
 
         Configurator::apply()
             ->withContainerAdapter(ExampleContainer::class, ExampleContainerAdapter::class)
             ->configFromArray([])
-            ->to($container);
+            ->to($exampleContainer);
 
-        assertSame(1, ExampleContainerAdapter::getNumberOfInstances());
+        $this->assertSame(1, ExampleContainerAdapter::getNumberOfInstances());
     }
 }

--- a/tests/unit/ContainerAdapterFactoryTest.php
+++ b/tests/unit/ContainerAdapterFactoryTest.php
@@ -1,8 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 namespace tests\unit\TomPHP\ContainerConfigurator;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use tests\mocks\ExampleContainer;
 use tests\mocks\ExampleContainerAdapter;
 use tests\mocks\ExampleExtendedContainer;
@@ -11,59 +13,56 @@ use TomPHP\ContainerConfigurator\ContainerAdapterFactory;
 use TomPHP\ContainerConfigurator\Exception\NotContainerAdapterException;
 use TomPHP\ContainerConfigurator\Exception\UnknownContainerException;
 
-final class ContainerAdapterFactoryTest extends PHPUnit_Framework_TestCase
+final class ContainerAdapterFactoryTest extends TestCase
 {
-    /**
-     * @var ContainerAdapterFactory
-     */
-    private $subject;
+    private \TomPHP\ContainerConfigurator\ContainerAdapterFactory $containerAdapterFactory;
 
-    protected function setUp()
+    protected function setUp(): void
     {
-        $this->subject = new ContainerAdapterFactory([
+        $this->containerAdapterFactory = new ContainerAdapterFactory([
             ExampleContainer::class => ExampleContainerAdapter::class,
         ]);
     }
 
-    public function testItCreatesAnInstanceOfTheContainerAdapter()
+    public function testItCreatesAnInstanceOfTheContainerAdapter(): void
     {
-        assertInstanceOf(
+        $this->assertInstanceOf(
             ExampleContainerAdapter::class,
-            $this->subject->create(new ExampleContainer())
+            $this->containerAdapterFactory->create(new ExampleContainer())
         );
     }
 
-    public function testItCreatesAnInstanceOfTheConfiguratorForSubclassedContainer()
+    public function testItCreatesAnInstanceOfTheConfiguratorForSubclassedContainer(): void
     {
-        assertInstanceOf(
+        $this->assertInstanceOf(
             ExampleContainerAdapter::class,
-            $this->subject->create(new ExampleExtendedContainer())
+            $this->containerAdapterFactory->create(new ExampleExtendedContainer())
         );
     }
 
-    public function testItThrowsIfContainerIsNotKnown()
+    public function testItThrowsIfContainerIsNotKnown(): void
     {
         $this->expectException(UnknownContainerException::class);
 
-        $this->subject->create(new \stdClass());
+        $this->containerAdapterFactory->create(new \stdClass());
     }
 
-    public function testItThrowsIfNotAContainerAdapter()
+    public function testItThrowsIfNotAContainerAdapter(): void
     {
-        $this->subject = new ContainerAdapterFactory([
+        $this->containerAdapterFactory = new ContainerAdapterFactory([
             ExampleContainer::class => NotContainerAdapter::class,
         ]);
 
         $this->expectException(NotContainerAdapterException::class);
 
-        $this->subject->create(new ExampleContainer());
+        $this->containerAdapterFactory->create(new ExampleContainer());
     }
 
-    public function testItSetsTheContainerOnTheConfigurator()
+    public function testItSetsTheContainerOnTheConfigurator(): void
     {
-        $container    = new ExampleContainer();
-        $configurator = $this->subject->create($container);
+        $exampleContainer    = new ExampleContainer();
+        $containerAdapter    = $this->containerAdapterFactory->create($exampleContainer);
 
-        assertSame($container, $configurator->getContainer());
+        $this->assertSame($exampleContainer, $containerAdapter->getContainer());
     }
 }

--- a/tests/unit/Exception/EntryDoesNotExistExceptionTest.php
+++ b/tests/unit/Exception/EntryDoesNotExistExceptionTest.php
@@ -1,27 +1,29 @@
 <?php
 
+declare(strict_types=1);
+
 namespace tests\unit\TomPHP\ContainerConfigurator\Exception;
 
 use DomainException;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use TomPHP\ContainerConfigurator\Exception\EntryDoesNotExistException;
 use TomPHP\ContainerConfigurator\Exception\Exception;
 
-final class EntryDoesNotExistExceptionTest extends PHPUnit_Framework_TestCase
+final class EntryDoesNotExistExceptionTest extends TestCase
 {
-    public function testItImplementsTheBaseExceptionType()
+    public function testItImplementsTheBaseExceptionType(): void
     {
-        assertInstanceOf(Exception::class, new EntryDoesNotExistException());
+        $this->assertInstanceOf(Exception::class, new EntryDoesNotExistException());
     }
 
-    public function testItIsADomainException()
+    public function testItIsADomainException(): void
     {
-        assertInstanceOf(DomainException::class, new EntryDoesNotExistException());
+        $this->assertInstanceOf(DomainException::class, new EntryDoesNotExistException());
     }
 
-    public function testItCanBeCreatedFromTheKey()
+    public function testItCanBeCreatedFromTheKey(): void
     {
-        assertSame(
+        $this->assertSame(
             'No entry found for "example-key".',
             EntryDoesNotExistException::fromKey('example-key')->getMessage()
         );

--- a/tests/unit/Exception/InvalidConfigExceptionTest.php
+++ b/tests/unit/Exception/InvalidConfigExceptionTest.php
@@ -1,67 +1,69 @@
 <?php
 
+declare(strict_types=1);
+
 namespace tests\unit\TomPHP\ContainerConfigurator\Exception;
 
 use LogicException;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use TomPHP\ContainerConfigurator\Exception\Exception;
 use TomPHP\ContainerConfigurator\Exception\InvalidConfigException;
 
-final class InvalidConfigExceptionTest extends PHPUnit_Framework_TestCase
+final class InvalidConfigExceptionTest extends TestCase
 {
-    public function testItImplementsTheBaseExceptionType()
+    public function testItImplementsTheBaseExceptionType(): void
     {
-        assertInstanceOf(Exception::class, new InvalidConfigException());
+        $this->assertInstanceOf(Exception::class, new InvalidConfigException());
     }
 
-    public function testItIsALogicException()
+    public function testItIsALogicException(): void
     {
-        assertInstanceOf(LogicException::class, new InvalidConfigException());
+        $this->assertInstanceOf(LogicException::class, new InvalidConfigException());
     }
 
-    public function testItCanBeCreatedFromTheFileName()
+    public function testItCanBeCreatedFromTheFileName(): void
     {
-        assertSame(
+        $this->assertSame(
             '"example.cfg" does not return a PHP array.',
             InvalidConfigException::fromPHPFileError('example.cfg')->getMessage()
         );
     }
 
-    public function testItCanBeCreatedWithAJSONFileError()
+    public function testItCanBeCreatedWithAJSONFileError(): void
     {
-        assertSame(
+        $this->assertSame(
             'Invalid JSON in "example.json": JSON Error Message',
             InvalidConfigException::fromJSONFileError('example.json', 'JSON Error Message')->getMessage()
         );
     }
 
-    public function testItCanBeCreatedFromYAMLFileError()
+    public function testItCanBeCreatedFromYAMLFileError(): void
     {
-        assertSame(
+        $this->assertSame(
             'Invalid YAML in "example.yml": YAML Error Message',
             InvalidConfigException::fromYAMLFileError('example.yml', 'YAML Error Message')->getMessage()
         );
     }
 
-    public function testItCanBeCreatedFromNameWhenClassAndFactoryAreSpecified()
+    public function testItCanBeCreatedFromNameWhenClassAndFactoryAreSpecified(): void
     {
-        assertSame(
+        $this->assertSame(
             'Both "class" and "factory" are specified for service "example"; these cannot be used together.',
             InvalidConfigException::fromNameWhenClassAndFactorySpecified('example')->getMessage()
         );
     }
 
-    public function testItCanBeCreatedFromNameWhenClassAndServiceAreSpecified()
+    public function testItCanBeCreatedFromNameWhenClassAndServiceAreSpecified(): void
     {
-        assertSame(
+        $this->assertSame(
             'Both "class" and "service" are specified for service "example"; these cannot be used together.',
             InvalidConfigException::fromNameWhenClassAndServiceSpecified('example')->getMessage()
         );
     }
 
-    public function testItCanBeCreatedFromNameWhenFactoryAndServiceAreSpecified()
+    public function testItCanBeCreatedFromNameWhenFactoryAndServiceAreSpecified(): void
     {
-        assertSame(
+        $this->assertSame(
             'Both "factory" and "service" are specified for service "example"; these cannot be used together.',
             InvalidConfigException::fromNameWhenFactoryAndServiceSpecified('example')->getMessage()
         );

--- a/tests/unit/Exception/MissingDependencyExceptionTest.php
+++ b/tests/unit/Exception/MissingDependencyExceptionTest.php
@@ -1,27 +1,29 @@
 <?php
 
+declare(strict_types=1);
+
 namespace tests\unit\TomPHP\ContainerConfigurator\Exception;
 
 use LogicException;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use TomPHP\ContainerConfigurator\Exception\Exception;
 use TomPHP\ContainerConfigurator\Exception\MissingDependencyException;
 
-final class MissingDependencyExceptionTest extends PHPUnit_Framework_TestCase
+final class MissingDependencyExceptionTest extends TestCase
 {
-    public function testItImplementsTheBaseExceptionType()
+    public function testItImplementsTheBaseExceptionType(): void
     {
-        assertInstanceOf(Exception::class, new MissingDependencyException());
+        $this->assertInstanceOf(Exception::class, new MissingDependencyException());
     }
 
-    public function testItIsALogicException()
+    public function testItIsALogicException(): void
     {
-        assertInstanceOf(LogicException::class, new MissingDependencyException());
+        $this->assertInstanceOf(LogicException::class, new MissingDependencyException());
     }
 
-    public function testItCanBeCreatedFromPackageName()
+    public function testItCanBeCreatedFromPackageName(): void
     {
-        assertSame(
+        $this->assertSame(
             'The package "foo/bar" is missing. Please run "composer require foo/bar" to install it.',
             MissingDependencyException::fromPackageName('foo/bar')->getMessage()
         );

--- a/tests/unit/Exception/NoMatchingFilesExceptionTest.php
+++ b/tests/unit/Exception/NoMatchingFilesExceptionTest.php
@@ -1,27 +1,29 @@
 <?php
 
+declare(strict_types=1);
+
 namespace tests\unit\TomPHP\ContainerConfigurator\Exception;
 
 use LogicException;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use TomPHP\ContainerConfigurator\Exception\Exception;
 use TomPHP\ContainerConfigurator\Exception\NoMatchingFilesException;
 
-final class NoMatchingFilesExceptionTest extends PHPUnit_Framework_TestCase
+final class NoMatchingFilesExceptionTest extends TestCase
 {
-    public function testItImplementsTheBaseExceptionType()
+    public function testItImplementsTheBaseExceptionType(): void
     {
-        assertInstanceOf(Exception::class, new NoMatchingFilesException());
+        $this->assertInstanceOf(Exception::class, new NoMatchingFilesException());
     }
 
-    public function testItIsALogicException()
+    public function testItIsALogicException(): void
     {
-        assertInstanceOf(LogicException::class, new NoMatchingFilesException());
+        $this->assertInstanceOf(LogicException::class, new NoMatchingFilesException());
     }
 
-    public function testItCanBeCreatedFromThePattern()
+    public function testItCanBeCreatedFromThePattern(): void
     {
-        assertSame(
+        $this->assertSame(
             'No files found matching pattern: "*.json".',
             NoMatchingFilesException::fromPattern('*.json')->getMessage()
         );

--- a/tests/unit/Exception/NotClassDefinitionExceptionTest.php
+++ b/tests/unit/Exception/NotClassDefinitionExceptionTest.php
@@ -1,27 +1,29 @@
 <?php
 
+declare(strict_types=1);
+
 namespace tests\unit\TomPHP\ContainerConfigurator\Exception;
 
 use LogicException;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use TomPHP\ContainerConfigurator\Exception\Exception;
 use TomPHP\ContainerConfigurator\Exception\NotClassDefinitionException;
 
-final class NotClassDefinitionExceptionTest extends PHPUnit_Framework_TestCase
+final class NotClassDefinitionExceptionTest extends TestCase
 {
-    public function testItImplementsTheBaseExceptionType()
+    public function testItImplementsTheBaseExceptionType(): void
     {
-        assertInstanceOf(Exception::class, new NotClassDefinitionException());
+        $this->assertInstanceOf(Exception::class, new NotClassDefinitionException());
     }
 
-    public function testItIsALogicException()
+    public function testItIsALogicException(): void
     {
-        assertInstanceOf(LogicException::class, new NotClassDefinitionException());
+        $this->assertInstanceOf(LogicException::class, new NotClassDefinitionException());
     }
 
-    public function testItCanBeCreatedFromThePatterns()
+    public function testItCanBeCreatedFromThePatterns(): void
     {
-        assertSame(
+        $this->assertSame(
             'Service configuration for "example-service" did not create a class definition.',
             NotClassDefinitionException::fromServiceName('example-service')->getMessage()
         );

--- a/tests/unit/Exception/NotContainerAdapterExceptionTest.php
+++ b/tests/unit/Exception/NotContainerAdapterExceptionTest.php
@@ -1,27 +1,29 @@
 <?php
 
+declare(strict_types=1);
+
 namespace tests\unit\TomPHP\ContainerConfigurator\Exception;
 
 use LogicException;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use TomPHP\ContainerConfigurator\Exception\Exception;
 use TomPHP\ContainerConfigurator\Exception\NotContainerAdapterException;
 
-final class NotContainerAdapterExceptionTest extends PHPUnit_Framework_TestCase
+final class NotContainerAdapterExceptionTest extends TestCase
 {
-    public function testItImplementsTheBaseExceptionType()
+    public function testItImplementsTheBaseExceptionType(): void
     {
-        assertInstanceOf(Exception::class, new NotContainerAdapterException());
+        $this->assertInstanceOf(Exception::class, new NotContainerAdapterException());
     }
 
-    public function testItIsALogicException()
+    public function testItIsALogicException(): void
     {
-        assertInstanceOf(LogicException::class, new NotContainerAdapterException());
+        $this->assertInstanceOf(LogicException::class, new NotContainerAdapterException());
     }
 
-    public function testItCanBeCreatedFromThePatterns()
+    public function testItCanBeCreatedFromThePatterns(): void
     {
-        assertSame(
+        $this->assertSame(
             'Class "Foo" is not a container adapter.',
             NotContainerAdapterException::fromClassName('Foo')->getMessage()
         );

--- a/tests/unit/Exception/ReadOnlyExceptionTest.php
+++ b/tests/unit/Exception/ReadOnlyExceptionTest.php
@@ -1,27 +1,29 @@
 <?php
 
+declare(strict_types=1);
+
 namespace tests\unit\TomPHP\ContainerConfigurator\Exception;
 
 use LogicException;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use TomPHP\ContainerConfigurator\Exception\Exception;
 use TomPHP\ContainerConfigurator\Exception\ReadOnlyException;
 
-final class ReadOnlyExceptionTest extends PHPUnit_Framework_TestCase
+final class ReadOnlyExceptionTest extends TestCase
 {
-    public function testItImplementsTheBaseExceptionType()
+    public function testItImplementsTheBaseExceptionType(): void
     {
-        assertInstanceOf(Exception::class, new ReadOnlyException());
+        $this->assertInstanceOf(Exception::class, new ReadOnlyException());
     }
 
-    public function testItIsALogicException()
+    public function testItIsALogicException(): void
     {
-        assertInstanceOf(LogicException::class, new ReadOnlyException());
+        $this->assertInstanceOf(LogicException::class, new ReadOnlyException());
     }
 
-    public function testItCanBeCreatedFromThePatterns()
+    public function testItCanBeCreatedFromThePatterns(): void
     {
-        assertSame(
+        $this->assertSame(
             '"ClassName" is read only.',
             ReadOnlyException::fromClassName('ClassName')->getMessage()
         );

--- a/tests/unit/Exception/UnknownContainerExceptionTest.php
+++ b/tests/unit/Exception/UnknownContainerExceptionTest.php
@@ -1,31 +1,34 @@
 <?php
 
+declare(strict_types=1);
+
 namespace tests\unit\TomPHP\ContainerConfigurator\Exception;
 
 use LogicException;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use TomPHP\ContainerConfigurator\Exception\Exception;
 use TomPHP\ContainerConfigurator\Exception\UnknownContainerException;
 
-final class UnknownContainerExceptionTest extends PHPUnit_Framework_TestCase
+final class UnknownContainerExceptionTest extends TestCase
 {
-    public function testItImplementsTheBaseExceptionType()
+    public function testItImplementsTheBaseExceptionType(): void
     {
-        assertInstanceOf(Exception::class, new UnknownContainerException());
+        $this->assertInstanceOf(Exception::class, new UnknownContainerException());
     }
 
-    public function testItIsADomainException()
+    public function testItIsADomainException(): void
     {
-        assertInstanceOf(LogicException::class, new UnknownContainerException());
+        $this->assertInstanceOf(LogicException::class, new UnknownContainerException());
     }
 
-    public function testItCanBeCreatedFromFileExtension()
+    public function testItCanBeCreatedFromFileExtension(): void
     {
-        $exception = UnknownContainerException::fromContainerName('example-container', ['container-a', 'container-b']);
+        $unknownContainerException =
+            UnknownContainerException::fromContainerName('example-container', ['container-a', 'container-b']);
 
-        assertSame(
+        $this->assertSame(
             'Container example-container is unknown; known containers are ["container-a", "container-b"].',
-            $exception->getMessage()
+            $unknownContainerException->getMessage()
         );
     }
 }

--- a/tests/unit/Exception/UnknownFileTypeExceptionTest.php
+++ b/tests/unit/Exception/UnknownFileTypeExceptionTest.php
@@ -1,31 +1,33 @@
 <?php
 
+declare(strict_types=1);
+
 namespace tests\unit\TomPHP\ContainerConfigurator\Exception;
 
 use DomainException;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use TomPHP\ContainerConfigurator\Exception\Exception;
 use TomPHP\ContainerConfigurator\Exception\UnknownFileTypeException;
 
-final class UnknownFileTypeExceptionTest extends PHPUnit_Framework_TestCase
+final class UnknownFileTypeExceptionTest extends TestCase
 {
-    public function testItImplementsTheBaseExceptionType()
+    public function testItImplementsTheBaseExceptionType(): void
     {
-        assertInstanceOf(Exception::class, new UnknownFileTypeException());
+        $this->assertInstanceOf(Exception::class, new UnknownFileTypeException());
     }
 
-    public function testItIsADomainException()
+    public function testItIsADomainException(): void
     {
-        assertInstanceOf(DomainException::class, new UnknownFileTypeException());
+        $this->assertInstanceOf(DomainException::class, new UnknownFileTypeException());
     }
 
-    public function testItCanBeCreatedFromFileExtension()
+    public function testItCanBeCreatedFromFileExtension(): void
     {
-        $exception = UnknownFileTypeException::fromFileExtension('.yml', ['.json', '.php']);
+        $unknownFileTypeException = UnknownFileTypeException::fromFileExtension('.yml', ['.json', '.php']);
 
-        assertSame(
+        $this->assertSame(
             'No reader configured for ".yml" files; readers are available for [".json", ".php"].',
-            $exception->getMessage()
+            $unknownFileTypeException->getMessage()
         );
     }
 }

--- a/tests/unit/Exception/UnknownSettingExceptionTest.php
+++ b/tests/unit/Exception/UnknownSettingExceptionTest.php
@@ -1,31 +1,33 @@
 <?php
 
+declare(strict_types=1);
+
 namespace tests\unit\TomPHP\ContainerConfigurator\Exception;
 
 use DomainException;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use TomPHP\ContainerConfigurator\Exception\Exception;
 use TomPHP\ContainerConfigurator\Exception\UnknownSettingException;
 
-final class UnknownSettingExceptionTest extends PHPUnit_Framework_TestCase
+final class UnknownSettingExceptionTest extends TestCase
 {
-    public function testItImplementsTheBaseExceptionType()
+    public function testItImplementsTheBaseExceptionType(): void
     {
-        assertInstanceOf(Exception::class, new UnknownSettingException());
+        $this->assertInstanceOf(Exception::class, new UnknownSettingException());
     }
 
-    public function testItIsADomainException()
+    public function testItIsADomainException(): void
     {
-        assertInstanceOf(DomainException::class, new UnknownSettingException());
+        $this->assertInstanceOf(DomainException::class, new UnknownSettingException());
     }
 
-    public function testItCanBeCreatedFromSetting()
+    public function testItCanBeCreatedFromSetting(): void
     {
-        $exception = UnknownSettingException::fromSetting('unknown', ['setting_a', 'setting_b']);
+        $unknownSettingException = UnknownSettingException::fromSetting('unknown', ['setting_a', 'setting_b']);
 
-        assertSame(
+        $this->assertSame(
             'Setting "unknown" is unknown; valid settings are ["setting_a", "setting_b"].',
-            $exception->getMessage()
+            $unknownSettingException->getMessage()
         );
     }
 }

--- a/tests/unit/FileReader/FileLocatorTest.php
+++ b/tests/unit/FileReader/FileLocatorTest.php
@@ -1,49 +1,48 @@
 <?php
 
+declare(strict_types=1);
+
 namespace tests\unit\TomPHP\ContainerConfigurator\FileReader;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use tests\support\TestFileCreator;
 use TomPHP\ContainerConfigurator\FileReader\FileLocator;
 
-final class FileLocatorTest extends PHPUnit_Framework_TestCase
+final class FileLocatorTest extends TestCase
 {
     use TestFileCreator;
 
-    /**
-     * @var FileLocator
-     */
-    private $locator;
+    private \TomPHP\ContainerConfigurator\FileReader\FileLocator $fileLocator;
 
-    protected function setUp()
+    protected function setUp(): void
     {
-        $this->locator = new FileLocator();
+        $this->fileLocator = new FileLocator();
     }
 
-    public function testItFindsFilesByGlobbing()
+    public function testItFindsFilesByGlobbing(): void
     {
         $this->createTestFile('config1.php');
         $this->createTestFile('config2.php');
         $this->createTestFile('config.json');
 
-        $files = $this->locator->locate($this->getTestPath('*.php'));
+        $files = $this->fileLocator->locate($this->getTestPath('*.php'));
 
-        assertEquals([
+        $this->assertSame([
             $this->getTestPath('config1.php'),
             $this->getTestPath('config2.php'),
         ], $files);
     }
 
-    public function testItFindsFindsFilesByGlobbingWithBraces()
+    public function testItFindsFindsFilesByGlobbingWithBraces(): void
     {
         $this->createTestFile('global.php');
         $this->createTestFile('database.local.php');
         $this->createTestFile('nothing.php');
         $this->createTestFile('nothing.php.dist');
 
-        $files = $this->locator->locate($this->getTestPath('{,*.}{global,local}.php'));
+        $files = $this->fileLocator->locate($this->getTestPath('{,*.}{global,local}.php'));
 
-        assertEquals([
+        $this->assertSame([
             $this->getTestPath('global.php'),
             $this->getTestPath('database.local.php'),
         ], $files);

--- a/tests/unit/FileReader/HJSONFileReaderTest.php
+++ b/tests/unit/FileReader/HJSONFileReaderTest.php
@@ -9,46 +9,50 @@ use PHPUnit\Framework\TestCase;
 use tests\support\TestFileCreator;
 use TomPHP\ContainerConfigurator\Exception\InvalidConfigException;
 use TomPHP\ContainerConfigurator\FileReader\FileReader;
-use TomPHP\ContainerConfigurator\FileReader\JSONFileReader;
+use TomPHP\ContainerConfigurator\FileReader\HJSONFileReader;
 
-final class JSONFileReaderTest extends TestCase
+final class HJSONFileReaderTest extends TestCase
 {
     use TestFileCreator;
 
-    private \TomPHP\ContainerConfigurator\FileReader\JSONFileReader $jsonFileReader;
+    private \TomPHP\ContainerConfigurator\FileReader\HJSONFileReader $hjsonFileReader;
 
     protected function setUp(): void
     {
-        $this->jsonFileReader = new JSONFileReader();
+        $this->hjsonFileReader = new HJSONFileReader();
     }
 
     public function testItIsAFileReader(): void
     {
-        $this->assertInstanceOf(FileReader::class, $this->jsonFileReader);
+        $this->assertInstanceOf(FileReader::class, $this->hjsonFileReader);
     }
 
     public function testItThrowsIfFileDoesNotExist(): void
     {
         $this->expectException(InvalidArgumentException::class);
 
-        $this->jsonFileReader->read('file-which-does-not-exist');
+        $this->hjsonFileReader->read('file-which-does-not-exist');
     }
 
     public function testReadsAPHPConfigFile(): void
     {
         $config = ['key' => 'value', 'sub' => ['key' => 'value']];
 
-        $this->createTestFile('config.json', json_encode($config));
+        $this->createTestFile('config.hjson', json_encode($config));
 
-        $this->assertEquals($config, $this->jsonFileReader->read($this->getTestPath('config.json')));
+        $this->assertEquals($config, $this->hjsonFileReader->read($this->getTestPath('config.hjson')));
     }
 
     public function testItThrowsIfTheConfigIsInvalid(): void
     {
         $this->expectException(InvalidConfigException::class);
 
-        $this->createTestFile('config.json', 'not json');
+        $invalidHjson = <<<HJSON
+        {
+                xxx
+        HJSON;
+        $this->createTestFile('config.hjson', $invalidHjson);
 
-        $this->jsonFileReader->read($this->getTestPath('config.json'));
+        $this->hjsonFileReader->read($this->getTestPath('config.hjson'));
     }
 }

--- a/tests/unit/FileReader/PHPFileReaderTest.php
+++ b/tests/unit/FileReader/PHPFileReaderTest.php
@@ -1,57 +1,56 @@
 <?php
 
+declare(strict_types=1);
+
 namespace tests\unit\TomPHP\ContainerConfigurator\FileReader;
 
 use InvalidArgumentException;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use tests\support\TestFileCreator;
 use TomPHP\ContainerConfigurator\Exception\InvalidConfigException;
 use TomPHP\ContainerConfigurator\FileReader\FileReader;
 use TomPHP\ContainerConfigurator\FileReader\PHPFileReader;
 
-final class PHPFileReaderTest extends PHPUnit_Framework_TestCase
+final class PHPFileReaderTest extends TestCase
 {
     use TestFileCreator;
 
-    /**
-     * @var PHPFileReader
-     */
-    private $reader;
+    private \TomPHP\ContainerConfigurator\FileReader\PHPFileReader $phpFileReader;
 
-    protected function setUp()
+    protected function setUp(): void
     {
-        $this->reader = new PHPFileReader();
+        $this->phpFileReader = new PHPFileReader();
     }
 
-    public function testItIsAFileReader()
+    public function testItIsAFileReader(): void
     {
-        assertInstanceOf(FileReader::class, $this->reader);
+        $this->assertInstanceOf(FileReader::class, $this->phpFileReader);
     }
 
-    public function testItThrowsIfFileDoesNotExist()
+    public function testItThrowsIfFileDoesNotExist(): void
     {
         $this->expectException(InvalidArgumentException::class);
 
-        $this->reader->read('file-which-does-not-exist');
+        $this->phpFileReader->read('file-which-does-not-exist');
     }
 
-    public function testReadsAPHPConfigFile()
+    public function testReadsAPHPConfigFile(): void
     {
         $config = ['key' => 'value'];
         $code   = '<?php return ' . var_export($config, true) . ';';
 
         $this->createTestFile('config.php', $code);
 
-        assertEquals($config, $this->reader->read($this->getTestPath('config.php')));
+        $this->assertEquals($config, $this->phpFileReader->read($this->getTestPath('config.php')));
     }
 
-    public function testItThrowsIfTheConfigIsInvalid()
+    public function testItThrowsIfTheConfigIsInvalid(): void
     {
         $this->expectException(InvalidConfigException::class);
 
         $code = '<?php return 123;';
         $this->createTestFile('config.php', $code);
 
-        $this->reader->read($this->getTestPath('config.php'));
+        $this->phpFileReader->read($this->getTestPath('config.php'));
     }
 }

--- a/tests/unit/FileReader/ReaderFactoryTest.php
+++ b/tests/unit/FileReader/ReaderFactoryTest.php
@@ -1,9 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace tests\unit\TomPHP\ContainerConfigurator\FileReader;
 
 use InvalidArgumentException;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use tests\support\TestFileCreator;
 use TomPHP\ContainerConfigurator\Exception\UnknownFileTypeException;
 use TomPHP\ContainerConfigurator\FileReader\JSONFileReader;
@@ -11,18 +13,15 @@ use TomPHP\ContainerConfigurator\FileReader\PHPFileReader;
 use TomPHP\ContainerConfigurator\FileReader\ReaderFactory;
 use TomPHP\ContainerConfigurator\FileReader\YAMLFileReader;
 
-final class ReaderFactoryTest extends PHPUnit_Framework_TestCase
+final class ReaderFactoryTest extends TestCase
 {
     use TestFileCreator;
 
-    /**
-     * @var ReaderFactory
-     */
-    private $factory;
+    private \TomPHP\ContainerConfigurator\FileReader\ReaderFactory $readerFactory;
 
-    protected function setUp()
+    protected function setUp(): void
     {
-        $this->factory = new ReaderFactory([
+        $this->readerFactory = new ReaderFactory([
             '.php'  => PHPFileReader::class,
             '.json' => JSONFileReader::class,
             '.yaml' => YAMLFileReader::class,
@@ -32,19 +31,16 @@ final class ReaderFactoryTest extends PHPUnit_Framework_TestCase
 
     /**
      * @dataProvider providerCreatesAppropriateFileReader
-     *
-     * @param string $extension
-     * @param string $fileReaderClass
      */
-    public function testCreatesAppropriateFileReader($extension, $fileReaderClass)
+    public function testCreatesAppropriateFileReader(string $extension, string $fileReaderClass): void
     {
         $filename = 'test' . $extension;
 
         $this->createTestFile($filename);
 
-        $reader = $this->factory->create($this->getTestPath($filename));
+        $fileReader = $this->readerFactory->create($this->getTestPath($filename));
 
-        assertInstanceOf($fileReaderClass, $reader);
+        $this->assertInstanceOf($fileReaderClass, $fileReader);
     }
 
     /**
@@ -67,30 +63,30 @@ final class ReaderFactoryTest extends PHPUnit_Framework_TestCase
         }
     }
 
-    public function testReturnsTheSameReaderForTheSameFileType()
+    public function testReturnsTheSameReaderForTheSameFileType(): void
     {
         $this->createTestFile('test1.php');
         $this->createTestFile('test2.php');
 
-        $reader1 = $this->factory->create($this->getTestPath('test1.php'));
-        $reader2 = $this->factory->create($this->getTestPath('test2.php'));
+        $fileReader = $this->readerFactory->create($this->getTestPath('test1.php'));
+        $reader2    = $this->readerFactory->create($this->getTestPath('test2.php'));
 
-        assertSame($reader1, $reader2);
+        $this->assertSame($fileReader, $reader2);
     }
 
-    public function testItThrowsIfTheArgumentIsNotAFileName()
+    public function testItThrowsIfTheArgumentIsNotAFileName(): void
     {
         $this->expectException(InvalidArgumentException::class);
 
-        $this->factory->create('missing-file.xxx');
+        $this->readerFactory->create('missing-file.xxx');
     }
 
-    public function testItThrowsIfThereIsNoRegisteredReaderForGivenFileType()
+    public function testItThrowsIfThereIsNoRegisteredReaderForGivenFileType(): void
     {
         $this->createTestFile('test.unknown');
 
         $this->expectException(UnknownFileTypeException::class);
 
-        $this->factory->create($this->getTestPath('test.unknown'));
+        $this->readerFactory->create($this->getTestPath('test.unknown'));
     }
 }

--- a/tests/unit/FileReader/YAMLFileReaderTest.php
+++ b/tests/unit/FileReader/YAMLFileReaderTest.php
@@ -1,56 +1,55 @@
 <?php
 
+declare(strict_types=1);
+
 namespace tests\unit\TomPHP\ContainerConfigurator\FileReader;
 
 use InvalidArgumentException;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Yaml;
 use tests\support\TestFileCreator;
 use TomPHP\ContainerConfigurator\Exception\InvalidConfigException;
 use TomPHP\ContainerConfigurator\FileReader\FileReader;
 use TomPHP\ContainerConfigurator\FileReader\YAMLFileReader;
 
-final class YAMLFileReaderTest extends PHPUnit_Framework_TestCase
+final class YAMLFileReaderTest extends TestCase
 {
     use TestFileCreator;
 
-    /**
-     * @var YAMLFileReader
-     */
-    private $reader;
+    private \TomPHP\ContainerConfigurator\FileReader\YAMLFileReader $yamlFileReader;
 
-    protected function setUp()
+    protected function setUp(): void
     {
-        $this->reader = new YAMLFileReader();
+        $this->yamlFileReader = new YAMLFileReader();
     }
 
-    public function testItIsAFileReader()
+    public function testItIsAFileReader(): void
     {
-        assertInstanceOf(FileReader::class, $this->reader);
+        $this->assertInstanceOf(FileReader::class, $this->yamlFileReader);
     }
 
-    public function testItThrowsIfFileDoesNotExist()
+    public function testItThrowsIfFileDoesNotExist(): void
     {
         $this->expectException(InvalidArgumentException::class);
 
-        $this->reader->read('file-which-does-not-exist');
+        $this->yamlFileReader->read('file-which-does-not-exist');
     }
 
-    public function testReadsAYAMLConfigFile()
+    public function testReadsAYAMLConfigFile(): void
     {
         $config = ['key' => 'value', 'sub' => ['key' => 'value']];
 
         $this->createTestFile('config.yml', Yaml\Yaml::dump($config));
 
-        assertEquals($config, $this->reader->read($this->getTestPath('config.yml')));
+        $this->assertEquals($config, $this->yamlFileReader->read($this->getTestPath('config.yml')));
     }
 
-    public function testItThrowsIfTheConfigIsInvalid()
+    public function testItThrowsIfTheConfigIsInvalid(): void
     {
         $this->expectException(InvalidConfigException::class);
 
         $this->createTestFile('config.yml', '[not yaml;');
 
-        $this->reader->read($this->getTestPath('config.yml'));
+        $this->yamlFileReader->read($this->getTestPath('config.yml'));
     }
 }

--- a/tests/unit/InflectorConfigTest.php
+++ b/tests/unit/InflectorConfigTest.php
@@ -1,23 +1,25 @@
 <?php
 
+declare(strict_types=1);
+
 namespace tests\unit\TomPHP\ContainerConfigurator;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use TomPHP\ContainerConfigurator\InflectorConfig;
 use TomPHP\ContainerConfigurator\InflectorDefinition;
 
-final class InflectorConfigTest extends PHPUnit_Framework_TestCase
+final class InflectorConfigTest extends TestCase
 {
-    public function testItMapsTheConfigArrayToInflectorDefinitions()
+    public function testItMapsTheConfigArrayToInflectorDefinitions(): void
     {
         $interface = 'example_interface';
         $methods   = ['method1' => ['arg1', 'arg2']];
 
-        $subject = new InflectorConfig([$interface => $methods]);
+        $inflectorConfig = new InflectorConfig([$interface => $methods]);
 
-        assertEquals(
+        $this->assertEquals(
             [new InflectorDefinition($interface, $methods)],
-            iterator_to_array($subject)
+            iterator_to_array($inflectorConfig)
         );
     }
 }

--- a/tests/unit/InflectorDefinitionTest.php
+++ b/tests/unit/InflectorDefinitionTest.php
@@ -1,35 +1,34 @@
 <?php
 
+declare(strict_types=1);
+
 namespace tests\unit\TomPHP\ContainerConfigurator;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use TomPHP\ContainerConfigurator\InflectorDefinition;
 
-final class InflectorDefinitionTest extends PHPUnit_Framework_TestCase
+final class InflectorDefinitionTest extends TestCase
 {
-    /**
-     * @var InflectorDefinition
-     */
-    private $subject;
+    private \TomPHP\ContainerConfigurator\InflectorDefinition $inflectorDefinition;
 
-    protected function setUp()
+    protected function setUp(): void
     {
-        $this->subject = new InflectorDefinition(
+        $this->inflectorDefinition = new InflectorDefinition(
             'interface_name',
             ['method1' => ['arg1', 'arg2']]
         );
     }
 
-    public function testGetInterfaceReturnsTheInterfaceName()
+    public function testGetInterfaceReturnsTheInterfaceName(): void
     {
-        assertEquals('interface_name', $this->subject->getInterface());
+        $this->assertSame('interface_name', $this->inflectorDefinition->getInterface());
     }
 
-    public function testGetMethodsReturnsTheMethods()
+    public function testGetMethodsReturnsTheMethods(): void
     {
-        assertEquals(
+        $this->assertSame(
             ['method1' => ['arg1', 'arg2']],
-            $this->subject->getMethods()
+            $this->inflectorDefinition->getMethods()
         );
     }
 }

--- a/tests/unit/ServiceConfigTest.php
+++ b/tests/unit/ServiceConfigTest.php
@@ -1,17 +1,19 @@
 <?php
 
+declare(strict_types=1);
+
 namespace tests\unit\TomPHP\ContainerConfigurator;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use TomPHP\ContainerConfigurator\ServiceConfig;
 use TomPHP\ContainerConfigurator\ServiceDefinition;
 
-final class ServiceConfigTest extends PHPUnit_Framework_TestCase
+final class ServiceConfigTest extends TestCase
 {
-    public function testFormatsASingleService()
+    public function testFormatsASingleService(): void
     {
         $serviceConfig = [
-            'class'     => __CLASS__,
+            'class'     => self::class,
             'singleton' => false,
             'arguments' => ['argument1', 'argument2'],
             'method'    => ['setSomething' => ['value']],
@@ -19,16 +21,16 @@ final class ServiceConfigTest extends PHPUnit_Framework_TestCase
 
         $config = new ServiceConfig(['service_name' => $serviceConfig]);
 
-        assertEquals(
+        $this->assertEquals(
             [new ServiceDefinition('service_name', $serviceConfig)],
             iterator_to_array($config)
         );
     }
 
-    public function testItProvidesAListOfKeys()
+    public function testItProvidesAListOfKeys(): void
     {
         $serviceConfig = [
-            'class'     => __CLASS__,
+            'class'     => self::class,
             'singleton' => false,
             'arguments' => ['argument1', 'argument2'],
             'method'    => ['setSomething' => ['value']],
@@ -39,15 +41,15 @@ final class ServiceConfigTest extends PHPUnit_Framework_TestCase
             'service2' => $serviceConfig,
         ]);
 
-        assertEquals(['service1', 'service2'], $config->getKeys());
+        $this->assertSame(['service1', 'service2'], $config->getKeys());
     }
 
-    public function testDefaultValueForSingletonCanBeSetToTrue()
+    public function testDefaultValueForSingletonCanBeSetToTrue(): void
     {
-        $serviceConfig = ['class' => __CLASS__];
+        $serviceConfig = ['class' => self::class];
 
         $config = new ServiceConfig(['service_name' => $serviceConfig], true);
 
-        assertTrue(iterator_to_array($config)[0]->isSingleton());
+        $this->assertTrue(iterator_to_array($config)[0]->isSingleton());
     }
 }

--- a/tests/unit/ServiceDefinitionTest.php
+++ b/tests/unit/ServiceDefinitionTest.php
@@ -1,103 +1,105 @@
 <?php
 
+declare(strict_types=1);
+
 namespace tests\unit\TomPHP\ContainerConfigurator;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use TomPHP\ContainerConfigurator\Exception\InvalidConfigException;
 use TomPHP\ContainerConfigurator\ServiceDefinition;
 
-final class ServiceDefinitionTest extends PHPUnit_Framework_TestCase
+final class ServiceDefinitionTest extends TestCase
 {
-    public function testItCreatesFromConfig()
+    public function testItCreatesFromConfig(): void
     {
         $config = [
-            'class'     => __CLASS__,
+            'class'     => self::class,
             'singleton' => false,
             'arguments' => ['argument1', 'argument2'],
             'methods'   => ['setSomething' => ['value']],
         ];
 
-        $definition = new ServiceDefinition('service_name', $config);
+        $serviceDefinition = new ServiceDefinition('service_name', $config);
 
-        assertEquals('service_name', $definition->getName());
-        assertEquals(__CLASS__, $definition->getClass());
-        assertFalse($definition->isFactory());
-        assertFalse($definition->isSingleton());
-        assertEquals(['argument1', 'argument2'], $definition->getArguments());
-        assertEquals(['setSomething' => ['value']], $definition->getMethods());
+        $this->assertSame('service_name', $serviceDefinition->getName());
+        $this->assertSame(self::class, $serviceDefinition->getClass());
+        $this->assertFalse($serviceDefinition->isFactory());
+        $this->assertFalse($serviceDefinition->isSingleton());
+        $this->assertSame(['argument1', 'argument2'], $serviceDefinition->getArguments());
+        $this->assertSame(['setSomething' => ['value']], $serviceDefinition->getMethods());
     }
 
-    public function testClassDefaultsToKey()
+    public function testClassDefaultsToKey(): void
     {
-        $definition = new ServiceDefinition('service_name', []);
+        $serviceDefinition = new ServiceDefinition('service_name', []);
 
-        assertEquals('service_name', $definition->getClass());
+        $this->assertSame('service_name', $serviceDefinition->getClass());
     }
 
-    public function testSingletonDefaultsToFalse()
+    public function testSingletonDefaultsToFalse(): void
     {
-        $definition = new ServiceDefinition('service_name', []);
+        $serviceDefinition = new ServiceDefinition('service_name', []);
 
-        assertFalse($definition->isSingleton());
+        $this->assertFalse($serviceDefinition->isSingleton());
     }
 
-    public function testSingletonDefaultCanBeSetToToTrue()
+    public function testSingletonDefaultCanBeSetToToTrue(): void
     {
-        $definition = new ServiceDefinition('service_name', [], true);
+        $serviceDefinition = new ServiceDefinition('service_name', [], true);
 
-        assertTrue($definition->isSingleton());
+        $this->assertTrue($serviceDefinition->isSingleton());
     }
 
-    public function testArgumentsDefaultToAnEmptyList()
+    public function testArgumentsDefaultToAnEmptyList(): void
     {
-        $definition = new ServiceDefinition('service_name', []);
+        $serviceDefinition = new ServiceDefinition('service_name', []);
 
-        assertEquals([], $definition->getArguments());
+        $this->assertSame([], $serviceDefinition->getArguments());
     }
 
-    public function testMethodsDefaultToAnEmptyList()
+    public function testMethodsDefaultToAnEmptyList(): void
     {
-        $definition = new ServiceDefinition('service_name', []);
+        $serviceDefinition = new ServiceDefinition('service_name', []);
 
-        assertEquals([], $definition->getMethods());
+        $this->assertSame([], $serviceDefinition->getMethods());
     }
 
-    public function testServiceFactoryDefinition()
+    public function testServiceFactoryDefinition(): void
     {
-        $definition = new ServiceDefinition('service_name', ['factory' => __CLASS__]);
+        $serviceDefinition = new ServiceDefinition('service_name', ['factory' => self::class]);
 
-        assertTrue($definition->isFactory());
-        assertFalse($definition->isAlias());
-        assertSame(__CLASS__, $definition->getClass());
+        $this->assertTrue($serviceDefinition->isFactory());
+        $this->assertFalse($serviceDefinition->isAlias());
+        $this->assertSame(self::class, $serviceDefinition->getClass());
     }
 
-    public function testServiceAliasDefinition()
+    public function testServiceAliasDefinition(): void
     {
-        $definition = new ServiceDefinition('service_name', ['service' => __CLASS__]);
+        $serviceDefinition = new ServiceDefinition('service_name', ['service' => self::class]);
 
-        assertTrue($definition->isAlias());
-        assertFalse($definition->isFactory());
-        assertSame(__CLASS__, $definition->getClass());
+        $this->assertTrue($serviceDefinition->isAlias());
+        $this->assertFalse($serviceDefinition->isFactory());
+        $this->assertSame(self::class, $serviceDefinition->getClass());
     }
 
-    public function testItThrowIfClassAndFactoryAreDefined()
-    {
-        $this->expectException(InvalidConfigException::class);
-
-        new ServiceDefinition('service_name', ['class' => __CLASS__, 'factory' => __CLASS__]);
-    }
-
-    public function testItThrowIfClassAndServiceAreDefined()
+    public function testItThrowIfClassAndFactoryAreDefined(): void
     {
         $this->expectException(InvalidConfigException::class);
 
-        new ServiceDefinition('service_name', ['class' => __CLASS__, 'service' => __CLASS__]);
+        new ServiceDefinition('service_name', ['class' => self::class, 'factory' => self::class]);
     }
 
-    public function testItThrowIfFactoryAndServiceAreDefined()
+    public function testItThrowIfClassAndServiceAreDefined(): void
     {
         $this->expectException(InvalidConfigException::class);
 
-        new ServiceDefinition('service_name', ['factory' => __CLASS__, 'service' => __CLASS__]);
+        new ServiceDefinition('service_name', ['class' => self::class, 'service' => self::class]);
+    }
+
+    public function testItThrowIfFactoryAndServiceAreDefined(): void
+    {
+        $this->expectException(InvalidConfigException::class);
+
+        new ServiceDefinition('service_name', ['factory' => self::class, 'service' => self::class]);
     }
 }


### PR DESCRIPTION
Okay, all done!

Thanks for merging the changes on tomphp/exception-constructor-tools by the way.

**Summary of changes below:**
 
* Minimum supported PHP version is now `8.1`.
* Upgraded dependencies:
  * beberlei/assert to `^3.3`
  * symfony/yaml to `^6.4`
  * tomphp/exception-constructor-tools to `^2.0`
* Added TomPHP\ContainerConfigurator\FileReader\HJSONFileReader for reading HJSON files (with accompanying tests)
* Applied phpstan at max level with related code cleanup
* Tweaked configuration handling: the full configuration array can now be accessed via the defined prefix (if provided), not just its keys. This complements the empty-prefix approach and should help with container namespacing safety.