### PR TITLE
Ensure unique identifiers for multiple configurators

### DIFF
--- a/src/League/ApplicationConfigServiceProvider.php
+++ b/src/League/ApplicationConfigServiceProvider.php
@@ -32,6 +32,7 @@ final class ApplicationConfigServiceProvider extends AbstractServiceProvider
     ) {
         Assertion::string($prefix);
 
+        $this->identifier = self::class . ($prefix !== '' ? $prefix : uniqid());
         $this->prefix   = $prefix;
         $this->provides = array_merge(array_map(
             fn (int|string $key): string => $this->keyPrefix() . $key,

--- a/tests/acceptance/SupportsApplicationConfig.php
+++ b/tests/acceptance/SupportsApplicationConfig.php
@@ -72,4 +72,64 @@ trait SupportsApplicationConfig
 
         $this->assertEquals('valueA', $this->container->get('keyA'));
     }
+
+    public function testItAddsMultipleConfiguratorsToTheContainer(): void
+    {
+        Configurator::apply()
+            ->configFromArray(['keyA' => 'valueA'])
+            ->withSetting(Configurator::SETTING_PREFIX, 'a')
+            ->to($this->container);
+
+        Configurator::apply()
+            ->configFromArray(['keyB' => 'valueB'])
+            ->withSetting(Configurator::SETTING_PREFIX, 'b')
+            ->to($this->container);
+
+        $this->assertEquals('valueA', $this->container->get('a.keyA'));
+        $this->assertEquals('valueB', $this->container->get('b.keyB'));
+    }
+
+    public function testItAddsMultipleConfiguratorsToTheContainerWithoutPrefixes(): void
+    {
+        Configurator::apply()
+            ->configFromArray(['keyA' => 'valueA'])
+            ->withSetting(Configurator::SETTING_PREFIX, '')
+            ->to($this->container);
+
+        Configurator::apply()
+            ->configFromArray(['keyB' => 'valueB'])
+            ->withSetting(Configurator::SETTING_PREFIX, '')
+            ->to($this->container);
+
+        $this->assertEquals('valueA', $this->container->get('keyA'));
+        $this->assertEquals('valueB', $this->container->get('keyB'));
+    }
+
+    public function testItAddsMultipleConfiguratorsToTheContainerWithAndWithoutPrefixes(): void
+    {
+        Configurator::apply()
+            ->configFromArray(['keyA' => 'valueA'])
+            ->withSetting(Configurator::SETTING_PREFIX, '')
+            ->to($this->container);
+
+        Configurator::apply()
+            ->configFromArray(['keyB' => 'valueB'])
+            ->withSetting(Configurator::SETTING_PREFIX, '')
+            ->to($this->container);
+
+        Configurator::apply()
+            ->configFromArray(['keyC' => 'valueC'])
+            ->withSetting(Configurator::SETTING_PREFIX, 'c')
+            ->to($this->container);
+
+        Configurator::apply()
+            ->configFromArray(['keyD' => 'valueD'])
+            ->withSetting(Configurator::SETTING_PREFIX, 'd')
+            ->to($this->container);
+
+        $this->assertEquals('valueA', $this->container->get('keyA'));
+        $this->assertEquals('valueB', $this->container->get('keyB'));
+        $this->assertEquals('valueC', $this->container->get('c.keyC'));
+        $this->assertEquals('valueD', $this->container->get('d.keyD'));
+    }
 }


### PR DESCRIPTION
I picked up a small bug while applying this library to a new project.

In League’s AbstractServiceProvider, the service provider identifier gets set with `$this->identifier = get_class($this)`. The catch is that when ApplicationConfigServiceProvider is registered _more than once_, every instance ends up sharing the same identifier, which causes collisions.

This is the outcome:

```
PHP Fatal error:  Uncaught League\Container\Exception\ContainerException: Service provider lied about providing (another-config) service in ...
```

I've updated the code for League's ApplicationConfigServiceProvider so it generates its own unique identifier.

If you pass in a prefix, the identifier becomes self::class . $prefix.

If you don’t, it falls back to uniqid() so each instance is guaranteed to be unique.

This means you can register multiple configurators (with or without prefixes) without them stepping on each other inside a League container.

The existing test suite never covered multiple configurator scenarios, which is why the bug was missed in the first round. New acceptance tests have been added to make sure it’s now covered.